### PR TITLE
feat: announcement-anchored Dutch auction with fill-size pricing (standalone extension)

### DIFF
--- a/config/constants.js
+++ b/config/constants.js
@@ -5,6 +5,7 @@ module.exports = {
     ACCESS_TOKEN_OWNER: constants.accessTokenOwner || {},
     CREATE3_DEPLOYERS: constants.create3Deployers || {},
     SETTLEMENT_SALT: constants.settlementSalt || {},
+    FUSION_ANCHORED_AUCTION_SALT: constants.fusionAnchoredAuctionSalt || {},
     SETTLEMENT_OWNER_ADDRESS: constants.settlementOwnerAddress || {},
     ACCESS_TOKEN_ADDRESS: constants.accessTokenAddress || {},
     WETH: constants.weth || {},

--- a/config/constants.js
+++ b/config/constants.js
@@ -13,6 +13,7 @@ module.exports = {
     DAO_ADDRESS: constants.daoAddress || {},
     POWER_POD_ADDRESS: constants.powerPodAddress || {},
     WHITELIST_REGISTRY_ADDRESS: constants.whitelistRegistryAddress || {},
+    ORDER_REGISTRATOR_ADDRESS: constants.orderRegistratorAddress || {},
     MINT_TO: constants.mintTo || {},
     MINT_TOKEN_ID: constants.mintTokenId || {},
     CONTRACT_ADDRESS: constants.contractAddress || {},

--- a/config/constants.json
+++ b/config/constants.json
@@ -21,5 +21,6 @@
     "59144": "0xD935a2bb926019E0ed6fb31fbD5b1Bbb7c05bf65",
     "146": "0xD935a2bb926019E0ed6fb31fbD5b1Bbb7c05bf65",
     "130": "0xD935a2bb926019E0ed6fb31fbD5b1Bbb7c05bf65"
-  }
+  },
+  "orderRegistratorAddress": {}
 }

--- a/config/constants.json
+++ b/config/constants.json
@@ -22,5 +22,6 @@
     "146": "0xD935a2bb926019E0ed6fb31fbD5b1Bbb7c05bf65",
     "130": "0xD935a2bb926019E0ed6fb31fbD5b1Bbb7c05bf65"
   },
+  "fusionAnchoredAuctionSalt": {},
   "orderRegistratorAddress": {}
 }

--- a/contracts/DutchAuctionBase.sol
+++ b/contracts/DutchAuctionBase.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.23;
+
+/**
+ * @title Dutch Auction base contract
+ * @notice Time-curve rate bump math shared by settlement contracts and auction extensions.
+ */
+abstract contract DutchAuctionBase {
+    uint256 internal constant _BASE_POINTS = 10_000_000; // 100%
+    uint256 internal constant _GAS_PRICE_BASE = 1_000_000; // 1000 means 1 Gwei
+
+    /**
+     * @dev Parses auction rate bump data from the `auctionDetails` field.
+     * `gasBumpEstimate` and `gasPriceEstimate` are used to estimate the transaction costs
+     * which are then offset from the auction rate bump.
+     * @param auctionDetails AuctionDetails is a tightly packed struct of the following format:
+     * ```
+     * struct AuctionDetails {
+     *     bytes3 gasBumpEstimate;
+     *     bytes4 gasPriceEstimate;
+     *     bytes4 auctionStartTime;
+     *     bytes3 auctionDuration;
+     *     bytes3 initialRateBump;
+     *     (bytes3,bytes2)[N] pointsAndTimeDeltas;
+     * }
+     * ```
+     * @return rateBump The rate bump.
+     * @return Remaining calldata after parsing auction data.
+     */
+    function _getRateBump(bytes calldata auctionDetails) internal view virtual returns (uint256, bytes calldata) {
+        unchecked {
+            uint256 gasBumpEstimate = uint24(bytes3(auctionDetails[0:3]));
+            uint256 gasPriceEstimate = uint32(bytes4(auctionDetails[3:7]));
+            uint256 gasBump = gasBumpEstimate == 0 || gasPriceEstimate == 0 ? 0 : gasBumpEstimate * block.basefee / gasPriceEstimate / _GAS_PRICE_BASE;
+            uint256 auctionStartTime = uint32(bytes4(auctionDetails[7:11]));
+            uint256 auctionFinishTime = auctionStartTime + uint24(bytes3(auctionDetails[11:14]));
+            uint256 initialRateBump = uint24(bytes3(auctionDetails[14:17]));
+            (uint256 auctionBump, bytes calldata tail) = _getAuctionBump(auctionStartTime, auctionFinishTime, initialRateBump, auctionDetails[17:]);
+            return (auctionBump > gasBump ? auctionBump - gasBump : 0, tail);
+        }
+    }
+
+    /**
+     * @dev Calculates auction price bump. Auction is represented as a piecewise linear function with `N` points.
+     * Each point is represented as a pair of `(rateBump, timeDelta)`, where `rateBump` is the
+     * rate bump in basis points and `timeDelta` is the time delta in seconds.
+     * The rate bump is interpolated linearly between the points.
+     * The last point is assumed to be `(0, auctionDuration)`.
+     * @param auctionStartTime The time when the auction starts.
+     * @param auctionFinishTime The time when the auction finishes.
+     * @param initialRateBump The initial rate bump.
+     * @param pointsAndTimeDeltas The points and time deltas structure.
+     * @return The rate bump at the current time.
+     * @return Remaining calldata after the parsed points.
+     */
+    function _getAuctionBump(
+        uint256 auctionStartTime, uint256 auctionFinishTime, uint256 initialRateBump, bytes calldata pointsAndTimeDeltas
+    ) internal view virtual returns (uint256, bytes calldata) {
+        unchecked {
+            uint256 currentPointTime = auctionStartTime;
+            uint256 currentRateBump = initialRateBump;
+            uint256 pointsCount = uint8(pointsAndTimeDeltas[0]);
+            pointsAndTimeDeltas = pointsAndTimeDeltas[1:];
+            bytes calldata tail = pointsAndTimeDeltas[5 * pointsCount:];
+
+            if (block.timestamp <= auctionStartTime) {
+                return (initialRateBump, tail);
+            } else if (block.timestamp >= auctionFinishTime) {
+                return (0, tail);
+            }
+
+            for (uint256 i = 0; i < pointsCount; i++) {
+                uint256 nextRateBump = uint24(bytes3(pointsAndTimeDeltas[:3]));
+                uint256 nextPointTime = currentPointTime + uint16(bytes2(pointsAndTimeDeltas[3:5]));
+                if (block.timestamp <= nextPointTime) {
+                    return (((block.timestamp - currentPointTime) * nextRateBump + (nextPointTime - block.timestamp) * currentRateBump) / (nextPointTime - currentPointTime), tail);
+                }
+                currentRateBump = nextRateBump;
+                currentPointTime = nextPointTime;
+                pointsAndTimeDeltas = pointsAndTimeDeltas[5:];
+            }
+            return ((auctionFinishTime - block.timestamp) * currentRateBump / (auctionFinishTime - currentPointTime), tail);
+        }
+    }
+}

--- a/contracts/SimpleSettlement.sol
+++ b/contracts/SimpleSettlement.sol
@@ -7,15 +7,14 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { IOrderMixin } from "@1inch/limit-order-protocol-contract/contracts/interfaces/IOrderMixin.sol";
 import { FeeTaker } from "@1inch/limit-order-protocol-contract/contracts/extensions/FeeTaker.sol";
 
+import { DutchAuctionBase } from "./DutchAuctionBase.sol";
+
 /**
  * @title Simple Settlement contract
  * @notice Contract to execute limit orders settlement, created by Fusion mode.
  */
-contract SimpleSettlement is FeeTaker {
+contract SimpleSettlement is FeeTaker, DutchAuctionBase {
     using Math for uint256;
-
-    uint256 private constant _BASE_POINTS = 10_000_000; // 100%
-    uint256 private constant _GAS_PRICE_BASE = 1_000_000; // 1000 means 1 Gwei
 
     error AllowedTimeViolation();
     error InvalidProtocolSurplusFee();
@@ -144,80 +143,6 @@ contract SimpleSettlement is FeeTaker {
             if (block.timestamp < allowedTime) {
                 revert AllowedTimeViolation();
             }
-        }
-    }
-
-    /**
-     * @dev Parses auction rate bump data from the `auctionDetails` field.
-     * `gasBumpEstimate` and `gasPriceEstimate` are used to estimate the transaction costs
-     * which are then offset from the auction rate bump.
-     * @param auctionDetails AuctionDetails is a tightly packed struct of the following format:
-     * ```
-     * struct AuctionDetails {
-     *     bytes3 gasBumpEstimate;
-     *     bytes4 gasPriceEstimate;
-     *     bytes4 auctionStartTime;
-     *     bytes3 auctionDuration;
-     *     bytes3 initialRateBump;
-     *     (bytes3,bytes2)[N] pointsAndTimeDeltas;
-     * }
-     * ```
-     * @return rateBump The rate bump.
-     * @return Remaining calldata after parsing auction data.
-     */
-    function _getRateBump(bytes calldata auctionDetails) private view returns (uint256, bytes calldata) {
-        unchecked {
-            uint256 gasBumpEstimate = uint24(bytes3(auctionDetails[0:3]));
-            uint256 gasPriceEstimate = uint32(bytes4(auctionDetails[3:7]));
-            uint256 gasBump = gasBumpEstimate == 0 || gasPriceEstimate == 0 ? 0 : gasBumpEstimate * block.basefee / gasPriceEstimate / _GAS_PRICE_BASE;
-            uint256 auctionStartTime = uint32(bytes4(auctionDetails[7:11]));
-            uint256 auctionFinishTime = auctionStartTime + uint24(bytes3(auctionDetails[11:14]));
-            uint256 initialRateBump = uint24(bytes3(auctionDetails[14:17]));
-            (uint256 auctionBump, bytes calldata tail) = _getAuctionBump(auctionStartTime, auctionFinishTime, initialRateBump, auctionDetails[17:]);
-            return (auctionBump > gasBump ? auctionBump - gasBump : 0, tail);
-        }
-    }
-
-    /**
-     * @dev Calculates auction price bump. Auction is represented as a piecewise linear function with `N` points.
-     * Each point is represented as a pair of `(rateBump, timeDelta)`, where `rateBump` is the
-     * rate bump in basis points and `timeDelta` is the time delta in seconds.
-     * The rate bump is interpolated linearly between the points.
-     * The last point is assumed to be `(0, auctionDuration)`.
-     * @param auctionStartTime The time when the auction starts.
-     * @param auctionFinishTime The time when the auction finishes.
-     * @param initialRateBump The initial rate bump.
-     * @param pointsAndTimeDeltas The points and time deltas structure.
-     * @return The rate bump at the current time.
-     * @return Remaining calldata after the parsed points.
-     */
-    function _getAuctionBump(
-        uint256 auctionStartTime, uint256 auctionFinishTime, uint256 initialRateBump, bytes calldata pointsAndTimeDeltas
-    ) private view returns (uint256, bytes calldata) {
-        unchecked {
-            uint256 currentPointTime = auctionStartTime;
-            uint256 currentRateBump = initialRateBump;
-            uint256 pointsCount = uint8(pointsAndTimeDeltas[0]);
-            pointsAndTimeDeltas = pointsAndTimeDeltas[1:];
-            bytes calldata tail = pointsAndTimeDeltas[5 * pointsCount:];
-
-            if (block.timestamp <= auctionStartTime) {
-                return (initialRateBump, tail);
-            } else if (block.timestamp >= auctionFinishTime) {
-                return (0, tail);
-            }
-
-            for (uint256 i = 0; i < pointsCount; i++) {
-                uint256 nextRateBump = uint24(bytes3(pointsAndTimeDeltas[:3]));
-                uint256 nextPointTime = currentPointTime + uint16(bytes2(pointsAndTimeDeltas[3:5]));
-                if (block.timestamp <= nextPointTime) {
-                    return (((block.timestamp - currentPointTime) * nextRateBump + (nextPointTime - block.timestamp) * currentRateBump) / (nextPointTime - currentPointTime), tail);
-                }
-                currentRateBump = nextRateBump;
-                currentPointTime = nextPointTime;
-                pointsAndTimeDeltas = pointsAndTimeDeltas[5:];
-            }
-            return ((auctionFinishTime - block.timestamp) * currentRateBump / (auctionFinishTime - currentPointTime), tail);
         }
     }
 }

--- a/contracts/extensions/FusionAnchoredAuction.sol
+++ b/contracts/extensions/FusionAnchoredAuction.sol
@@ -12,7 +12,8 @@ import { IOrderRegistrator } from "../interfaces/IOrderRegistrator.sol";
 
 /**
  * @title FusionAnchoredAuction
- * @notice Dutch auction whose schedule may be anchored to the moment an order was announced on-chain.
+ * @notice Dutch auction whose schedule may be anchored to the moment an order was announced on-chain,
+ * and whose price may depend on how much of the order a taker fills.
  * @dev A standalone amount getter and post-interaction, referenced by address from the order extension —
  * directly or chained behind an already deployed settlement contract — so it requires no settlement
  * redeployment. Each feature is opt-in per order through a flags byte; with no flags set the pricing
@@ -22,8 +23,13 @@ import { IOrderRegistrator } from "../interfaces/IOrderRegistrator.sol";
 contract FusionAnchoredAuction is AmountGetterBase, DutchAuctionBase, IPostInteraction {
     /// @dev Measure from `announcedAt` instead of the built timestamp alone. Shared by both blobs.
     bytes1 private constant _ANCHORED_FLAG = 0x01;
+    /// @dev Auction-details flag: price a fill by a piecewise premium curve over the order's volume ladder.
+    bytes1 private constant _FILL_CURVE_FLAG = 0x02;
     /// @dev Exclusivity-blob flag: stop fills after `announcedAt` plus the deadline delay.
     bytes1 private constant _ANNOUNCEMENT_DEADLINE_FLAG = 0x02;
+
+    /// @dev Fill shares are measured in 1e4.
+    uint256 private constant _SHARE_BASE = 10_000;
 
     /// @dev The order relies on its announcement but was never announced.
     error OrderNotAnnounced();
@@ -31,6 +37,8 @@ contract FusionAnchoredAuction is AmountGetterBase, DutchAuctionBase, IPostInter
     error AuctionExpired();
     /// @dev The taker may not fill the order yet.
     error AllowedTimeViolation();
+    /// @dev A premium that rises along the volume ladder would reward splitting a fill.
+    error NonMonotonicFillCurve();
     /// @dev A flag was set without the flag it depends on.
     error InvalidFlagCombination();
 
@@ -116,7 +124,10 @@ contract FusionAnchoredAuction is AmountGetterBase, DutchAuctionBase, IPostInter
     }
 
     /**
-     * @dev Adds anchored dutch auction capabilities to the getter.
+     * @dev Adds anchored dutch auction capabilities to the getter. The fill share is not known here —
+     * it is the value being computed — so it is estimated at the worst rate bump the auction can produce
+     * and the price is recomputed from that estimate. The estimate can only understate the share and
+     * therefore only overstate the rate bump, so the result never exceeds an exact solution.
      */
     function _getMakingAmount(
         IOrderMixin.Order calldata order,
@@ -127,16 +138,22 @@ contract FusionAnchoredAuction is AmountGetterBase, DutchAuctionBase, IPostInter
         uint256 remainingMakingAmount,
         bytes calldata extraData
     ) internal view override returns (uint256) {
-        (uint256 rateBump, bytes calldata tail) = _parseRateBump(extraData, orderHash);
-        return Math.mulDiv(
-            super._getMakingAmount(order, extension, orderHash, taker, takingAmount, remainingMakingAmount, tail),
-            _BASE_POINTS,
-            _BASE_POINTS + rateBump
-        );
+        (uint256 auctionBump, uint256 gasBump, bytes calldata fillCurve, bytes calldata tail) = _parseAuctionDetails(extraData, orderHash);
+        uint256 unbumpedAmount = super._getMakingAmount(order, extension, orderHash, taker, takingAmount, remainingMakingAmount, tail);
+
+        uint256 rateBump = auctionBump;
+        if (fillCurve.length != 0) {
+            // The curve is enforced non-increasing, so its initial premium is the worst it can price at.
+            uint256 worstRateBump = auctionBump + uint24(bytes3(fillCurve[0:3]));
+            uint256 estimatedMakingAmount = Math.mulDiv(unbumpedAmount, _BASE_POINTS, _BASE_POINTS + _applyGasBump(worstRateBump, gasBump));
+            rateBump = _rateBumpForFill(auctionBump, fillCurve, estimatedMakingAmount, remainingMakingAmount);
+        }
+
+        return Math.mulDiv(unbumpedAmount, _BASE_POINTS, _BASE_POINTS + _applyGasBump(rateBump, gasBump));
     }
 
     /**
-     * @dev Adds anchored dutch auction capabilities to the getter.
+     * @dev Adds anchored dutch auction capabilities to the getter, where the fill share is known exactly.
      */
     function _getTakingAmount(
         IOrderMixin.Order calldata order,
@@ -147,7 +164,8 @@ contract FusionAnchoredAuction is AmountGetterBase, DutchAuctionBase, IPostInter
         uint256 remainingMakingAmount,
         bytes calldata extraData
     ) internal view override returns (uint256) {
-        (uint256 rateBump, bytes calldata tail) = _parseRateBump(extraData, orderHash);
+        (uint256 auctionBump, uint256 gasBump, bytes calldata fillCurve, bytes calldata tail) = _parseAuctionDetails(extraData, orderHash);
+        uint256 rateBump = _applyGasBump(_rateBumpForFill(auctionBump, fillCurve, makingAmount, remainingMakingAmount), gasBump);
         return Math.mulDiv(
             super._getTakingAmount(order, extension, orderHash, taker, makingAmount, remainingMakingAmount, tail),
             _BASE_POINTS + rateBump,
@@ -157,7 +175,7 @@ contract FusionAnchoredAuction is AmountGetterBase, DutchAuctionBase, IPostInter
     }
 
     /**
-     * @dev Parses the auction rate bump, resolving an anchored start from the announcement.
+     * @dev Parses the auction, resolving everything that does not depend on the fill size.
      * @param auctionDetails AuctionDetails is a tightly packed struct of the following format:
      * ```
      * struct AuctionDetails {
@@ -167,17 +185,26 @@ contract FusionAnchoredAuction is AmountGetterBase, DutchAuctionBase, IPostInter
      *     bytes4 auctionStartTime;
      *     bytes3 auctionDuration;
      *     bytes3 initialRateBump;
+     *     FillCurve fillCurve;           // present when the fill curve flag is set
      *     bytes1 pointsCount;
      *     (bytes3,bytes2)[N] pointsAndTimeDeltas;
+     * }
+     *
+     * struct FillCurve {
+     *     bytes3 initialFillPremium;
+     *     bytes1 fillPointsCount;
+     *     (bytes3,bytes2)[M] premiumsAndShareDeltas;
      * }
      * ```
      * An anchored auction starts at the later of its announcement and the built start time, so a
      * stale built start is ignored while a deliberately delayed one still holds.
      * @param orderHash The hash of the order, the key the announcement is recorded under.
-     * @return rateBump The rate bump at the current time.
-     * @return Remaining calldata after parsing auction data.
+     * @return auctionBump The time curve's rate bump at the current moment.
+     * @return gasBump The rate-bump offset estimating the taker's transaction costs.
+     * @return fillCurve The premium curve over fill shares, empty when the order does not carry one.
+     * @return tail Remaining calldata after the auction.
      */
-    function _parseRateBump(bytes calldata auctionDetails, bytes32 orderHash) private view returns (uint256, bytes calldata) {
+    function _parseAuctionDetails(bytes calldata auctionDetails, bytes32 orderHash) private view returns (uint256 auctionBump, uint256 gasBump, bytes calldata fillCurve, bytes calldata tail) {
         unchecked {
             bytes1 flags = auctionDetails[0];
             uint256 gasBumpEstimate = uint24(bytes3(auctionDetails[1:4]));
@@ -185,15 +212,80 @@ contract FusionAnchoredAuction is AmountGetterBase, DutchAuctionBase, IPostInter
             uint256 auctionStartTime = uint32(bytes4(auctionDetails[8:12]));
             uint256 auctionDuration = uint24(bytes3(auctionDetails[12:15]));
             uint256 initialRateBump = uint24(bytes3(auctionDetails[15:18]));
+            uint256 offset = 18;
 
             if (flags & _ANCHORED_FLAG != 0) {
                 uint256 anchoredStartTime = _announcedAt(orderHash);
                 if (anchoredStartTime > auctionStartTime) auctionStartTime = anchoredStartTime;
             }
 
-            uint256 gasBump = gasBumpEstimate == 0 || gasPriceEstimate == 0 ? 0 : gasBumpEstimate * block.basefee / gasPriceEstimate / _GAS_PRICE_BASE;
-            (uint256 auctionBump, bytes calldata tail) = _getAuctionBump(auctionStartTime, auctionStartTime + auctionDuration, initialRateBump, auctionDetails[18:]);
-            return (auctionBump > gasBump ? auctionBump - gasBump : 0, tail);
+            if (flags & _FILL_CURVE_FLAG != 0) {
+                uint256 fillCurveLength = 4 + 5 * uint256(uint8(auctionDetails[offset + 3]));
+                fillCurve = auctionDetails[offset:offset + fillCurveLength];
+                offset += fillCurveLength;
+            } else {
+                fillCurve = auctionDetails[0:0];
+            }
+
+            gasBump = gasBumpEstimate == 0 || gasPriceEstimate == 0 ? 0 : gasBumpEstimate * block.basefee / gasPriceEstimate / _GAS_PRICE_BASE;
+            (auctionBump, tail) = _getAuctionBump(auctionStartTime, auctionStartTime + auctionDuration, initialRateBump, auctionDetails[offset:]);
+        }
+    }
+
+    /**
+     * @dev The rate bump a fill is priced at: the time curve's bump, plus the fill premium for a fill
+     * that leaves part of the order behind. A completing fill never reads the curve.
+     */
+    function _rateBumpForFill(uint256 auctionBump, bytes calldata fillCurve, uint256 makingAmount, uint256 remainingMakingAmount) private pure returns (uint256) {
+        unchecked {
+            if (fillCurve.length == 0 || makingAmount >= remainingMakingAmount) return auctionBump;
+            return auctionBump + _fillPremium(makingAmount, remainingMakingAmount, fillCurve);
+        }
+    }
+
+    /**
+     * @dev Reads the premium a fill pays from the piecewise curve over the order's volume ladder.
+     * A fill is priced by its own share of what remains, measured in 1e4 of `remainingMakingAmount`,
+     * so every fill sees the remainder as a fresh ladder and a completing fill pays no premium at all.
+     * The curve starts at the initial premium for a vanishing fill, is interpolated linearly between
+     * points, and ends at an implied final point of zero premium at the full remainder. The premium
+     * must not increase along the ladder — a rising stretch would pay takers to split a fill — and the
+     * walk enforces that lazily, one comparison per visited point.
+     * @param makingAmount The making amount of this fill, strictly below the remainder.
+     * @param remainingMakingAmount The making amount left on the order before this fill.
+     * @param fillCurve The packed curve: 3 bytes initial premium, 1 byte count, (3 bytes, 2 bytes) points.
+     * @return The premium this fill pays on top of the time curve's rate bump.
+     */
+    function _fillPremium(uint256 makingAmount, uint256 remainingMakingAmount, bytes calldata fillCurve) private pure returns (uint256) {
+        unchecked {
+            uint256 currentPremium = uint24(bytes3(fillCurve[0:3]));
+            uint256 share = Math.mulDiv(makingAmount, _SHARE_BASE, remainingMakingAmount);
+            if (share == 0) return currentPremium;
+
+            uint256 currentShare = 0;
+            uint256 pointsCount = uint8(fillCurve[3]);
+            bytes calldata points = fillCurve[4:];
+            for (uint256 i = 0; i < pointsCount; i++) {
+                uint256 nextPremium = uint24(bytes3(points[:3]));
+                if (nextPremium > currentPremium) revert NonMonotonicFillCurve();
+                uint256 nextShare = currentShare + uint16(bytes2(points[3:5]));
+                if (share <= nextShare) {
+                    return ((share - currentShare) * nextPremium + (nextShare - share) * currentPremium) / (nextShare - currentShare);
+                }
+                currentPremium = nextPremium;
+                currentShare = nextShare;
+                points = points[5:];
+            }
+            return (_SHARE_BASE - share) * currentPremium / (_SHARE_BASE - currentShare);
+        }
+    }
+
+    /**
+     * @dev Offsets the estimated transaction costs from the auction rate bump.
+     */
+    function _applyGasBump(uint256 rateBump, uint256 gasBump) private pure returns (uint256) {
+        unchecked {
+            return rateBump > gasBump ? rateBump - gasBump : 0;
         }
     }
 

--- a/contracts/extensions/FusionAnchoredAuction.sol
+++ b/contracts/extensions/FusionAnchoredAuction.sol
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.23;
+
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { IOrderMixin } from "@1inch/limit-order-protocol-contract/contracts/interfaces/IOrderMixin.sol";
+import { IPostInteraction } from "@1inch/limit-order-protocol-contract/contracts/interfaces/IPostInteraction.sol";
+import { AmountGetterBase } from "@1inch/limit-order-protocol-contract/contracts/extensions/AmountGetterBase.sol";
+
+import { DutchAuctionBase } from "../DutchAuctionBase.sol";
+import { IOrderRegistrator } from "../interfaces/IOrderRegistrator.sol";
+
+/**
+ * @title FusionAnchoredAuction
+ * @notice Dutch auction whose schedule may be anchored to the moment an order was announced on-chain.
+ * @dev A standalone amount getter and post-interaction, referenced by address from the order extension —
+ * directly or chained behind an already deployed settlement contract — so it requires no settlement
+ * redeployment. Each feature is opt-in per order through a flags byte; with no flags set the pricing
+ * matches the settlement's own Dutch auction. Amount getters can be skipped by a mis-assembled order,
+ * so the announcement deadline lives in the post-interaction, which cannot.
+ */
+contract FusionAnchoredAuction is AmountGetterBase, DutchAuctionBase, IPostInteraction {
+    /// @dev Measure from `announcedAt` instead of the built timestamp alone. Shared by both blobs.
+    bytes1 private constant _ANCHORED_FLAG = 0x01;
+    /// @dev Exclusivity-blob flag: stop fills after `announcedAt` plus the deadline delay.
+    bytes1 private constant _ANNOUNCEMENT_DEADLINE_FLAG = 0x02;
+
+    /// @dev The order relies on its announcement but was never announced.
+    error OrderNotAnnounced();
+    /// @dev The order is past its announcement deadline.
+    error AuctionExpired();
+    /// @dev The taker may not fill the order yet.
+    error AllowedTimeViolation();
+    /// @dev A flag was set without the flag it depends on.
+    error InvalidFlagCombination();
+
+    IOrderRegistrator private immutable _ORDER_REGISTRATOR;
+
+    /// @param orderRegistrator The registrator whose announcements anchored orders are measured from.
+    constructor(IOrderRegistrator orderRegistrator) {
+        _ORDER_REGISTRATOR = orderRegistrator;
+    }
+
+    /**
+     * @notice See {IPostInteraction-postInteraction}.
+     * @dev Holds resolver exclusivity relative to the announcement and enforces the optional
+     * announcement deadline. Deliberately callable by anyone: it moves no funds and only reverts,
+     * and when chained the caller is a settlement contract, not the limit order protocol.
+     * `extraData` consists of:
+     * ```
+     * 1 byte - flags
+     * 4 bytes - allowed time
+     * 3 bytes - anchored allowed-time delay (present when the anchored flag is set)
+     * 3 bytes - announcement deadline delay (present when the deadline flag is set)
+     * 1 byte - size of the whitelist
+     * (bytes10,bytes2)[N] - whitelisted address low bytes and the time delta until the next one
+     * bytes - custom data to call an extra post-interaction (optional)
+     * ```
+     * The anchored allowed time is `announcedAt + delay`, taking the max against the absolute allowed
+     * time. The deadline reverts fills strictly after `announcedAt + deadline delay` and requires the
+     * anchored flag: alone it fails closed rather than silently doing nothing.
+     */
+    function postInteraction(
+        IOrderMixin.Order calldata order,
+        bytes calldata extension,
+        bytes32 orderHash,
+        address taker,
+        uint256 makingAmount,
+        uint256 takingAmount,
+        uint256 remainingMakingAmount,
+        bytes calldata extraData
+    ) external {
+        unchecked {
+            bytes1 flags = extraData[0];
+            uint256 allowedTime = uint32(bytes4(extraData[1:5]));
+            uint256 offset = 5;
+
+            if (flags & _ANCHORED_FLAG != 0) {
+                uint256 announcementTime = _announcedAt(orderHash);
+                uint256 anchoredTime = announcementTime + uint24(bytes3(extraData[offset:offset + 3]));
+                offset += 3;
+                if (anchoredTime > allowedTime) allowedTime = anchoredTime;
+
+                if (flags & _ANNOUNCEMENT_DEADLINE_FLAG != 0) {
+                    if (block.timestamp > announcementTime + uint24(bytes3(extraData[offset:offset + 3]))) revert AuctionExpired();
+                    offset += 3;
+                }
+            } else if (flags & _ANNOUNCEMENT_DEADLINE_FLAG != 0) {
+                revert InvalidFlagCombination();
+            }
+
+            uint256 size = uint8(extraData[offset]);
+            offset += 1;
+            bytes calldata whitelist = extraData[offset:offset + 12 * size];
+            bytes calldata tail = extraData[offset + 12 * size:];
+
+            uint80 maskedTakerAddress = uint80(uint160(taker));
+            bool whitelisted;
+            for (uint256 i = 0; i < size; i++) {
+                if (block.timestamp < allowedTime) revert AllowedTimeViolation();
+                if (maskedTakerAddress == uint80(bytes10(whitelist))) {
+                    whitelisted = true;
+                    break;
+                }
+                allowedTime += uint16(bytes2(whitelist[10:])); // add next time delta
+                whitelist = whitelist[12:];
+            }
+            if (!whitelisted && block.timestamp < allowedTime) revert AllowedTimeViolation();
+
+            if (tail.length > 19) {
+                IPostInteraction(address(bytes20(tail))).postInteraction(
+                    order, extension, orderHash, taker, makingAmount, takingAmount, remainingMakingAmount, tail[20:]
+                );
+            }
+        }
+    }
+
+    /**
+     * @dev Adds anchored dutch auction capabilities to the getter.
+     */
+    function _getMakingAmount(
+        IOrderMixin.Order calldata order,
+        bytes calldata extension,
+        bytes32 orderHash,
+        address taker,
+        uint256 takingAmount,
+        uint256 remainingMakingAmount,
+        bytes calldata extraData
+    ) internal view override returns (uint256) {
+        (uint256 rateBump, bytes calldata tail) = _parseRateBump(extraData, orderHash);
+        return Math.mulDiv(
+            super._getMakingAmount(order, extension, orderHash, taker, takingAmount, remainingMakingAmount, tail),
+            _BASE_POINTS,
+            _BASE_POINTS + rateBump
+        );
+    }
+
+    /**
+     * @dev Adds anchored dutch auction capabilities to the getter.
+     */
+    function _getTakingAmount(
+        IOrderMixin.Order calldata order,
+        bytes calldata extension,
+        bytes32 orderHash,
+        address taker,
+        uint256 makingAmount,
+        uint256 remainingMakingAmount,
+        bytes calldata extraData
+    ) internal view override returns (uint256) {
+        (uint256 rateBump, bytes calldata tail) = _parseRateBump(extraData, orderHash);
+        return Math.mulDiv(
+            super._getTakingAmount(order, extension, orderHash, taker, makingAmount, remainingMakingAmount, tail),
+            _BASE_POINTS + rateBump,
+            _BASE_POINTS,
+            Math.Rounding.Ceil
+        );
+    }
+
+    /**
+     * @dev Parses the auction rate bump, resolving an anchored start from the announcement.
+     * @param auctionDetails AuctionDetails is a tightly packed struct of the following format:
+     * ```
+     * struct AuctionDetails {
+     *     bytes1 flags;
+     *     bytes3 gasBumpEstimate;
+     *     bytes4 gasPriceEstimate;
+     *     bytes4 auctionStartTime;
+     *     bytes3 auctionDuration;
+     *     bytes3 initialRateBump;
+     *     bytes1 pointsCount;
+     *     (bytes3,bytes2)[N] pointsAndTimeDeltas;
+     * }
+     * ```
+     * An anchored auction starts at the later of its announcement and the built start time, so a
+     * stale built start is ignored while a deliberately delayed one still holds.
+     * @param orderHash The hash of the order, the key the announcement is recorded under.
+     * @return rateBump The rate bump at the current time.
+     * @return Remaining calldata after parsing auction data.
+     */
+    function _parseRateBump(bytes calldata auctionDetails, bytes32 orderHash) private view returns (uint256, bytes calldata) {
+        unchecked {
+            bytes1 flags = auctionDetails[0];
+            uint256 gasBumpEstimate = uint24(bytes3(auctionDetails[1:4]));
+            uint256 gasPriceEstimate = uint32(bytes4(auctionDetails[4:8]));
+            uint256 auctionStartTime = uint32(bytes4(auctionDetails[8:12]));
+            uint256 auctionDuration = uint24(bytes3(auctionDetails[12:15]));
+            uint256 initialRateBump = uint24(bytes3(auctionDetails[15:18]));
+
+            if (flags & _ANCHORED_FLAG != 0) {
+                uint256 anchoredStartTime = _announcedAt(orderHash);
+                if (anchoredStartTime > auctionStartTime) auctionStartTime = anchoredStartTime;
+            }
+
+            uint256 gasBump = gasBumpEstimate == 0 || gasPriceEstimate == 0 ? 0 : gasBumpEstimate * block.basefee / gasPriceEstimate / _GAS_PRICE_BASE;
+            (uint256 auctionBump, bytes calldata tail) = _getAuctionBump(auctionStartTime, auctionStartTime + auctionDuration, initialRateBump, auctionDetails[18:]);
+            return (auctionBump > gasBump ? auctionBump - gasBump : 0, tail);
+        }
+    }
+
+    /**
+     * @dev Reads the announcement of an order, reverting when it has never been announced.
+     */
+    function _announcedAt(bytes32 orderHash) private view returns (uint256) {
+        uint256 announcedAt = _ORDER_REGISTRATOR.announcedAt(orderHash);
+        if (announcedAt == 0) revert OrderNotAnnounced();
+        return announcedAt;
+    }
+}

--- a/contracts/interfaces/IOrderRegistrator.sol
+++ b/contracts/interfaces/IOrderRegistrator.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.23;
+
+/**
+ * @title IOrderRegistrator
+ * @notice The announcement surface of the order registrator that anchored auctions read.
+ */
+interface IOrderRegistrator {
+    /**
+     * @notice Returns the time an order was first registered, or zero when it never was.
+     * @param orderHash The hash of the order.
+     * @return timestamp The block timestamp of the first registration.
+     */
+    function announcedAt(bytes32 orderHash) external view returns (uint256 timestamp);
+}

--- a/contracts/mocks/OrderRegistratorMock.sol
+++ b/contracts/mocks/OrderRegistratorMock.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.23;
+
+import { IOrderMixin } from "@1inch/limit-order-protocol-contract/contracts/interfaces/IOrderMixin.sol";
+
+import { IOrderRegistrator } from "../interfaces/IOrderRegistrator.sol";
+
+/// @title Records announcements the way the order registrator does: write-once, at the current timestamp.
+contract OrderRegistratorMock is IOrderRegistrator {
+    IOrderMixin private immutable _LIMIT_ORDER_PROTOCOL;
+
+    mapping(bytes32 orderHash => uint256 timestamp) private _announcedAt;
+
+    constructor(IOrderMixin limitOrderProtocol) {
+        _LIMIT_ORDER_PROTOCOL = limitOrderProtocol;
+    }
+
+    function registerOrder(IOrderMixin.Order calldata order) external {
+        bytes32 orderHash = _LIMIT_ORDER_PROTOCOL.hashOrder(order);
+        if (_announcedAt[orderHash] == 0) {
+            _announcedAt[orderHash] = block.timestamp;
+        }
+    }
+
+    function announcedAt(bytes32 orderHash) external view returns (uint256 timestamp) {
+        return _announcedAt[orderHash];
+    }
+}

--- a/deploy/deploy-fusion-anchored-auction.js
+++ b/deploy/deploy-fusion-anchored-auction.js
@@ -1,9 +1,9 @@
 const hre = require('hardhat');
-const { deployAndGetContract } = require('@1inch/solidity-utils');
+const { deployAndGetContractWithCreate3, deployAndGetContract } = require('@1inch/solidity-utils');
 const constants = require('../config/constants');
-const { getChainId } = hre;
+const { getChainId, ethers } = hre;
 
-module.exports = async ({ getNamedAccounts, deployments }) => {
+module.exports = async ({ getNamedAccounts, deployments, config }) => {
     const networkName = hre.network.name;
     console.log(`running ${networkName} deploy script`);
     const chainId = await getChainId();
@@ -18,6 +18,11 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
         return;
     }
 
+    let DEPLOYMENT_METHOD = config.deployOpts?.deploymentMethod || 'create3';
+    if (networkName.indexOf('zksync') !== -1) { // create3 is not supported for zksync
+        DEPLOYMENT_METHOD = 'create';
+    }
+
     // The OrderRegistrator with the announcedAt view (limit-order-protocol#435) is not deployed yet;
     // fill config/constants.json once it is.
     const orderRegistrator = constants.ORDER_REGISTRATOR_ADDRESS[chainId];
@@ -25,15 +30,42 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
         throw new Error(`orderRegistratorAddress is not set for chain ${chainId} in config/constants.json`);
     }
 
-    const { deployer } = await getNamedAccounts();
+    const constructorArgs = [orderRegistrator];
 
-    await deployAndGetContract({
-        contractName: 'FusionAnchoredAuction',
-        constructorArgs: [orderRegistrator],
-        deployments,
-        deployer,
-        skipVerify: process.env.OPS_SKIP_VERIFY === 'true',
-    });
+    const deploymentName = 'FusionAnchoredAuction';
+    const contractName = 'FusionAnchoredAuction';
+
+    if (DEPLOYMENT_METHOD === 'create3') {
+        let salt = constants.FUSION_ANCHORED_AUCTION_SALT[chainId];
+        if (!salt) {
+            throw new Error(`fusionAnchoredAuctionSalt is not set for chain ${chainId} in config/constants.json`);
+        }
+        salt = salt.startsWith('0x') ? salt : ethers.keccak256(ethers.toUtf8Bytes(salt));
+
+        console.log(`Using salt: ${salt}`);
+
+        // Deploy with create3
+        await deployAndGetContractWithCreate3({
+            contractName,
+            deploymentName,
+            constructorArgs,
+            create3Deployer: constants.CREATE3_DEPLOYERS[chainId],
+            salt,
+            deployments,
+            skipVerify: process.env.OPS_SKIP_VERIFY === 'true',
+        });
+    } else {
+        // Deploy on zkSync-like networks without create3
+        const { deployer } = await getNamedAccounts();
+        await deployAndGetContract({
+            contractName,
+            deploymentName,
+            constructorArgs,
+            deployments,
+            deployer,
+            skipVerify: process.env.OPS_SKIP_VERIFY === 'true',
+        });
+    }
 };
 
 module.exports.skip = async () => true;

--- a/deploy/deploy-fusion-anchored-auction.js
+++ b/deploy/deploy-fusion-anchored-auction.js
@@ -1,0 +1,39 @@
+const hre = require('hardhat');
+const { deployAndGetContract } = require('@1inch/solidity-utils');
+const constants = require('../config/constants');
+const { getChainId } = hre;
+
+module.exports = async ({ getNamedAccounts, deployments }) => {
+    const networkName = hre.network.name;
+    console.log(`running ${networkName} deploy script`);
+    const chainId = await getChainId();
+    console.log('network id ', chainId);
+
+    if (
+        networkName in hre.config.networks &&
+        chainId !== hre.config.networks[networkName].chainId?.toString()
+    ) {
+        console.log(`network chain id: ${hre.config.networks[networkName].chainId}, your chain id ${chainId}`);
+        console.log('skipping wrong chain id deployment');
+        return;
+    }
+
+    // The OrderRegistrator with the announcedAt view (limit-order-protocol#435) is not deployed yet;
+    // fill config/constants.json once it is.
+    const orderRegistrator = constants.ORDER_REGISTRATOR_ADDRESS[chainId];
+    if (!orderRegistrator) {
+        throw new Error(`orderRegistratorAddress is not set for chain ${chainId} in config/constants.json`);
+    }
+
+    const { deployer } = await getNamedAccounts();
+
+    await deployAndGetContract({
+        contractName: 'FusionAnchoredAuction',
+        constructorArgs: [orderRegistrator],
+        deployments,
+        deployer,
+        skipVerify: process.env.OPS_SKIP_VERIFY === 'true',
+    });
+};
+
+module.exports.skip = async () => true;

--- a/scripts/mint-kyc.js
+++ b/scripts/mint-kyc.js
@@ -2,7 +2,7 @@ const hre = require('hardhat');
 const { ethers } = hre;
 const constants = require('../config/constants');
 
-async function main () {
+async function main() {
     const networkName = hre.network.name;
     const chainId = (await ethers.provider.getNetwork()).chainId.toString();
     console.log(`running ${networkName} (chainId: ${chainId}) mint-kyc script`);

--- a/scripts/transfer-ownership.js
+++ b/scripts/transfer-ownership.js
@@ -10,7 +10,7 @@ const OWNABLE_ABI = [
 // OZ v5 Ownable custom error selector: OwnableUnauthorizedAccount(address)
 const OWNABLE_UNAUTHORIZED_SELECTOR = ethers.id('OwnableUnauthorizedAccount(address)').slice(0, 10);
 
-async function main () {
+async function main() {
     const networkName = hre.network.name;
     const chainId = (await ethers.provider.getNetwork()).chainId.toString();
     console.log(`running ${networkName} (chainId: ${chainId}) transfer-ownership script`);

--- a/test/FusionAnchoredAuction.js
+++ b/test/FusionAnchoredAuction.js
@@ -1,0 +1,556 @@
+const hre = require('hardhat');
+const { ethers } = hre;
+const { expect, ether, deployContract } = require('@1inch/solidity-utils');
+const { loadFixture, time } = require('@nomicfoundation/hardhat-network-helpers');
+const { buildOrder, buildTakerTraits, signOrder } = require('@1inch/limit-order-protocol-contract/test/helpers/orderUtils');
+const { deploySwapTokens, getChainId } = require('./helpers/fixtures');
+const { buildSettlementExtensions } = require('./helpers/fusionUtils');
+const {
+    BASE_POINTS,
+    NO_FEE_DATA,
+    ceilDiv,
+    buildLegacyAuctionDetails,
+    buildAnchoredAuctionDetails,
+    buildAnchoredExclusivity,
+    takingAmountFor,
+} = require('./helpers/anchoredAuction');
+
+const HALF_PERCENT = 50_000n; // 0.5% in 1e7
+
+describe('FusionAnchoredAuction', function () {
+    let maker, taker, otherResolver;
+
+    before(async function () {
+        [maker, taker, otherResolver] = await ethers.getSigners();
+    });
+
+    async function deployContractsAndInit() {
+        const { dai, weth, accessToken, lopv4 } = await deploySwapTokens();
+        const chainId = await getChainId();
+
+        await dai.approve(lopv4, ether('1000'));
+        await weth.connect(taker).deposit({ value: ether('1') });
+        await weth.connect(taker).approve(lopv4, ether('1'));
+        await weth.connect(otherResolver).deposit({ value: ether('1') });
+        await weth.connect(otherResolver).approve(lopv4, ether('1'));
+        await accessToken.mint(taker, 1);
+
+        const registrator = await deployContract('OrderRegistratorMock', [lopv4]);
+        const auction = await deployContract('FusionAnchoredAuction', [registrator]);
+        const settlement = await deployContract('SimpleSettlement', [lopv4, accessToken, weth, maker]);
+
+        return { dai, weth, accessToken, lopv4, chainId, registrator, auction, settlement };
+    }
+
+    const MAKING_AMOUNT = ether('100');
+    const TAKING_AMOUNT = ether('0.1');
+
+    /** An order priced solely by the auction contract, with no settlement layer in front of it. */
+    async function buildAuctionOrder({ dai, weth, auction, auctionDetails, exclusivity, receiver }) {
+        const auctionAddress = await auction.getAddress();
+        return buildOrder(
+            {
+                maker: maker.address,
+                receiver,
+                makerAsset: await dai.getAddress(),
+                takerAsset: await weth.getAddress(),
+                makingAmount: MAKING_AMOUNT,
+                takingAmount: TAKING_AMOUNT,
+            },
+            {
+                makingAmountData: ethers.solidityPacked(['address', 'bytes'], [auctionAddress, auctionDetails]),
+                takingAmountData: ethers.solidityPacked(['address', 'bytes'], [auctionAddress, auctionDetails]),
+                postInteraction: exclusivity === undefined
+                    ? '0x'
+                    : ethers.solidityPacked(['address', 'bytes'], [auctionAddress, exclusivity]),
+            },
+        );
+    }
+
+    async function signature(order, chainId, lopv4) {
+        return ethers.Signature.from(await signOrder(order, chainId, await lopv4.getAddress(), maker));
+    }
+
+    async function announce(registrator, order) {
+        await registrator.registerOrder(order);
+        return await time.latest();
+    }
+
+    function fill(lopv4, order, sig, amount, { byMakingAmount = true, from = taker, overrides = {} } = {}) {
+        const takerTraits = buildTakerTraits({ makingAmount: byMakingAmount, extension: order.extension });
+        return lopv4.connect(from).fillOrderArgs(order, sig.r, sig.yParityAndS, amount, takerTraits.traits, takerTraits.args, overrides);
+    }
+
+    describe('announcement-anchored auction', function () {
+        const anchoredParams = { startTime: 0, duration: 100, initialRateBump: Number(HALF_PERCENT), anchored: true };
+
+        it('reverts when the order was never announced', async function () {
+            const { dai, weth, lopv4, chainId, auction } = await loadFixture(deployContractsAndInit);
+
+            const order = await buildAuctionOrder({ dai, weth, auction, auctionDetails: buildAnchoredAuctionDetails(anchoredParams) });
+            const sig = await signature(order, chainId, lopv4);
+
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT)).to.be.revertedWithCustomError(auction, 'OrderNotAnnounced');
+        });
+
+        it('starts the auction at the announcement however stale the built start time is', async function () {
+            const { dai, weth, lopv4, chainId, registrator, auction } = await loadFixture(deployContractsAndInit);
+
+            const order = await buildAuctionOrder({ dai, weth, auction, auctionDetails: buildAnchoredAuctionDetails(anchoredParams) });
+            const sig = await signature(order, chainId, lopv4);
+
+            // A build-time start of 0 is long past; the announcement is what the auction runs from.
+            const announcedAt = await announce(registrator, order);
+            const resolved = { ...anchoredParams, startTime: announcedAt };
+
+            const fillTime = resolved.startTime + 50;
+            await time.setNextBlockTimestamp(fillTime);
+            const fillTx = fill(lopv4, order, sig, MAKING_AMOUNT);
+
+            const expected = takingAmountFor(order, resolved, fillTime, MAKING_AMOUNT, MAKING_AMOUNT);
+            expect(expected).to.equal(ceilDiv(TAKING_AMOUNT * (BASE_POINTS + HALF_PERCENT / 2n), BASE_POINTS));
+            await expect(fillTx).to.changeTokenBalances(weth, [taker, maker], [-expected, expected]);
+        });
+
+        it('keeps a build-time start that is later than the announcement', async function () {
+            const { dai, weth, lopv4, chainId, registrator, auction } = await loadFixture(deployContractsAndInit);
+
+            const startTime = await time.latest() + 1000;
+            const params = { ...anchoredParams, startTime };
+            const order = await buildAuctionOrder({ dai, weth, auction, auctionDetails: buildAnchoredAuctionDetails(params) });
+            const sig = await signature(order, chainId, lopv4);
+
+            const announcedAt = await announce(registrator, order);
+            expect(announcedAt).to.be.lessThan(startTime);
+
+            // Anchoring may only move the start later, so the auction has not begun yet.
+            const fillTime = announcedAt + 20;
+            await time.setNextBlockTimestamp(fillTime);
+            const fillTx = fill(lopv4, order, sig, MAKING_AMOUNT);
+
+            const expected = takingAmountFor(order, params, fillTime, MAKING_AMOUNT, MAKING_AMOUNT);
+            expect(expected).to.equal(ceilDiv(TAKING_AMOUNT * (BASE_POINTS + HALF_PERCENT), BASE_POINTS));
+            await expect(fillTx).to.changeTokenBalances(weth, [taker, maker], [-expected, expected]);
+        });
+
+        it('prices a fill announced in the same block at the top of the curve', async function () {
+            const { dai, weth, lopv4, chainId, registrator, auction } = await loadFixture(deployContractsAndInit);
+
+            const order = await buildAuctionOrder({ dai, weth, auction, auctionDetails: buildAnchoredAuctionDetails(anchoredParams) });
+            const sig = await signature(order, chainId, lopv4);
+
+            // The maker announces and a resolver fills in the same block; the fill sees the announcement
+            // written earlier in the block and prices at the very start of the curve.
+            await hre.network.provider.send('evm_setAutomine', [false]);
+            let announceTx, fillTx;
+            try {
+                announceTx = await registrator.registerOrder(order, { gasLimit: 300000 });
+                const takerTraits = buildTakerTraits({ makingAmount: true, extension: order.extension });
+                fillTx = await lopv4.connect(taker).fillOrderArgs(
+                    order, sig.r, sig.yParityAndS, MAKING_AMOUNT, takerTraits.traits, takerTraits.args, { gasLimit: 500000 },
+                );
+            } finally {
+                await hre.network.provider.send('evm_setAutomine', [true]);
+                await hre.network.provider.send('evm_mine');
+            }
+
+            const announceReceipt = await announceTx.wait();
+            const fillReceipt = await fillTx.wait();
+            expect(announceReceipt.blockNumber).to.equal(fillReceipt.blockNumber);
+
+            const expected = ceilDiv(TAKING_AMOUNT * (BASE_POINTS + HALF_PERCENT), BASE_POINTS);
+            expect(await weth.balanceOf(maker)).to.equal(expected);
+            expect(await dai.balanceOf(taker)).to.equal(MAKING_AMOUNT);
+            expect(await registrator.announcedAt(await lopv4.hashOrder(order))).to.equal(await time.latest());
+        });
+
+        it('gives a slow announcement the same curve a prompt one gets', async function () {
+            const { dai, weth, lopv4, chainId, registrator, auction } = await loadFixture(deployContractsAndInit);
+
+            const order = await buildAuctionOrder({ dai, weth, auction, auctionDetails: buildAnchoredAuctionDetails(anchoredParams) });
+            const sig = await signature(order, chainId, lopv4);
+
+            // Announce hours after the order was built, as a multisig collecting signatures would.
+            await time.increase(6 * 60 * 60);
+            const announcedAt = await announce(registrator, order);
+
+            const fillTime = announcedAt + 1;
+            await time.setNextBlockTimestamp(fillTime);
+            const fillTx = fill(lopv4, order, sig, MAKING_AMOUNT);
+
+            // One second into the anchored curve — essentially the top, rather than the floor price an
+            // unanchored order would have decayed to hours ago.
+            const expected = takingAmountFor(order, { ...anchoredParams, startTime: announcedAt }, fillTime, MAKING_AMOUNT, MAKING_AMOUNT);
+            expect(expected).to.be.greaterThan(ceilDiv(TAKING_AMOUNT * (BASE_POINTS + HALF_PERCENT * 9n / 10n), BASE_POINTS));
+            await expect(fillTx).to.changeTokenBalances(weth, [taker, maker], [-expected, expected]);
+        });
+    });
+
+    describe('announcement-anchored resolver exclusivity', function () {
+        const auctionParams = { startTime: 0, duration: 100, initialRateBump: Number(HALF_PERCENT), anchored: true };
+
+        it('holds the exclusive window open relative to the announcement', async function () {
+            const { dai, weth, lopv4, chainId, registrator, auction } = await loadFixture(deployContractsAndInit);
+
+            const order = await buildAuctionOrder({
+                dai,
+                weth,
+                auction,
+                auctionDetails: buildAnchoredAuctionDetails(auctionParams),
+                exclusivity: buildAnchoredExclusivity({
+                    allowedTimeDelay: 30,
+                    whitelist: [{ address: taker.address }],
+                }),
+            });
+            const sig = await signature(order, chainId, lopv4);
+            const announcedAt = await announce(registrator, order);
+
+            await time.setNextBlockTimestamp(announcedAt + 29);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT)).to.be.revertedWithCustomError(auction, 'AllowedTimeViolation');
+
+            await time.setNextBlockTimestamp(announcedAt + 30);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT)).to.changeTokenBalances(dai, [taker, maker], [MAKING_AMOUNT, -MAKING_AMOUNT]);
+        });
+
+        it('makes a resolver outside the whitelist wait out every window', async function () {
+            const { dai, weth, lopv4, chainId, registrator, auction } = await loadFixture(deployContractsAndInit);
+
+            const order = await buildAuctionOrder({
+                dai,
+                weth,
+                auction,
+                auctionDetails: buildAnchoredAuctionDetails(auctionParams),
+                exclusivity: buildAnchoredExclusivity({
+                    allowedTimeDelay: 10,
+                    whitelist: [{ address: taker.address, delta: 20 }],
+                }),
+            });
+            const sig = await signature(order, chainId, lopv4);
+            const announcedAt = await announce(registrator, order);
+
+            await time.setNextBlockTimestamp(announcedAt + 25);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT, { from: otherResolver }))
+                .to.be.revertedWithCustomError(auction, 'AllowedTimeViolation');
+
+            await time.setNextBlockTimestamp(announcedAt + 30);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT, { from: otherResolver }))
+                .to.changeTokenBalances(dai, [otherResolver, maker], [MAKING_AMOUNT, -MAKING_AMOUNT]);
+        });
+
+        it('keeps a built allowed time that is later than the anchored one', async function () {
+            const { dai, weth, lopv4, chainId, registrator, auction } = await loadFixture(deployContractsAndInit);
+
+            const allowedTime = await time.latest() + 100;
+            const order = await buildAuctionOrder({
+                dai,
+                weth,
+                auction,
+                auctionDetails: buildAnchoredAuctionDetails(auctionParams),
+                exclusivity: buildAnchoredExclusivity({
+                    allowedTime,
+                    allowedTimeDelay: 5,
+                    whitelist: [{ address: taker.address }],
+                }),
+            });
+            const sig = await signature(order, chainId, lopv4);
+            const announcedAt = await announce(registrator, order);
+            expect(announcedAt + 5).to.be.lessThan(allowedTime);
+
+            // Anchoring may only move the window later, mirroring the auction start's max() semantics.
+            await time.setNextBlockTimestamp(allowedTime - 1);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT)).to.be.revertedWithCustomError(auction, 'AllowedTimeViolation');
+
+            await time.setNextBlockTimestamp(allowedTime);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT)).to.changeTokenBalances(dai, [taker, maker], [MAKING_AMOUNT, -MAKING_AMOUNT]);
+        });
+
+        it('staggers two whitelisted resolvers by their deltas', async function () {
+            const { dai, weth, lopv4, chainId, registrator, auction } = await loadFixture(deployContractsAndInit);
+
+            const order = await buildAuctionOrder({
+                dai,
+                weth,
+                auction,
+                auctionDetails: buildAnchoredAuctionDetails(auctionParams),
+                exclusivity: buildAnchoredExclusivity({
+                    allowedTimeDelay: 10,
+                    whitelist: [
+                        { address: taker.address, delta: 20 },
+                        { address: otherResolver.address },
+                    ],
+                }),
+            });
+            const sig = await signature(order, chainId, lopv4);
+            const announcedAt = await announce(registrator, order);
+
+            // The second resolver is whitelisted but its window opens a delta after the first one's.
+            await time.setNextBlockTimestamp(announcedAt + 15);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT / 2n, { from: otherResolver }))
+                .to.be.revertedWithCustomError(auction, 'AllowedTimeViolation');
+
+            await time.setNextBlockTimestamp(announcedAt + 16);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT / 2n))
+                .to.changeTokenBalances(dai, [taker, maker], [MAKING_AMOUNT / 2n, -MAKING_AMOUNT / 2n]);
+
+            await time.setNextBlockTimestamp(announcedAt + 30);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT / 2n, { from: otherResolver }))
+                .to.changeTokenBalances(dai, [otherResolver, maker], [MAKING_AMOUNT / 2n, -MAKING_AMOUNT / 2n]);
+        });
+
+        it('gates everyone by the anchored time when the whitelist is empty', async function () {
+            const { dai, weth, lopv4, chainId, registrator, auction } = await loadFixture(deployContractsAndInit);
+
+            const order = await buildAuctionOrder({
+                dai,
+                weth,
+                auction,
+                auctionDetails: buildAnchoredAuctionDetails(auctionParams),
+                exclusivity: buildAnchoredExclusivity({ allowedTimeDelay: 30, whitelist: [] }),
+            });
+            const sig = await signature(order, chainId, lopv4);
+            const announcedAt = await announce(registrator, order);
+
+            await time.setNextBlockTimestamp(announcedAt + 29);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT)).to.be.revertedWithCustomError(auction, 'AllowedTimeViolation');
+
+            await time.setNextBlockTimestamp(announcedAt + 30);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT)).to.changeTokenBalances(dai, [taker, maker], [MAKING_AMOUNT, -MAKING_AMOUNT]);
+        });
+
+        it('stops fills once the announcement deadline has passed', async function () {
+            const { dai, weth, lopv4, chainId, registrator, auction } = await loadFixture(deployContractsAndInit);
+
+            const order = await buildAuctionOrder({
+                dai,
+                weth,
+                auction,
+                auctionDetails: buildAnchoredAuctionDetails(auctionParams),
+                exclusivity: buildAnchoredExclusivity({
+                    allowedTimeDelay: 0,
+                    announcementDeadlineDelay: 120,
+                    whitelist: [{ address: taker.address }],
+                }),
+            });
+            const sig = await signature(order, chainId, lopv4);
+            const announcedAt = await announce(registrator, order);
+
+            // On the deadline itself the order still fills — the cutoff is strictly after it.
+            await time.setNextBlockTimestamp(announcedAt + 120);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT / 2n))
+                .to.changeTokenBalances(dai, [taker, maker], [MAKING_AMOUNT / 2n, -MAKING_AMOUNT / 2n]);
+
+            await time.setNextBlockTimestamp(announcedAt + 121);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT / 2n)).to.be.revertedWithCustomError(auction, 'AuctionExpired');
+        });
+
+        it('rejects a deadline that is not anchored', async function () {
+            const { dai, weth, lopv4, chainId, auction } = await loadFixture(deployContractsAndInit);
+
+            // The deadline is measured from the announcement, so without the anchored bit there is
+            // nothing to measure it from — the combination fails closed instead of silently no-oping.
+            const order = await buildAuctionOrder({
+                dai,
+                weth,
+                auction,
+                auctionDetails: buildAnchoredAuctionDetails({ startTime: 0, duration: 100, initialRateBump: 0 }),
+                exclusivity: buildAnchoredExclusivity({
+                    announcementDeadlineDelay: 120,
+                    whitelist: [{ address: taker.address }],
+                }),
+            });
+            const sig = await signature(order, chainId, lopv4);
+
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT)).to.be.revertedWithCustomError(auction, 'InvalidFlagCombination');
+        });
+
+        it('passes the fill on to the next post-interaction', async function () {
+            const { dai, weth, lopv4, chainId, registrator, auction } = await loadFixture(deployContractsAndInit);
+
+            const customExtension = await deployContract('CustomExtension');
+
+            const order = await buildAuctionOrder({
+                dai,
+                weth,
+                auction,
+                auctionDetails: buildAnchoredAuctionDetails(auctionParams),
+                exclusivity: ethers.solidityPacked(
+                    ['bytes', 'address', 'bytes'],
+                    [
+                        buildAnchoredExclusivity({ allowedTimeDelay: 0, whitelist: [{ address: taker.address }] }),
+                        await customExtension.getAddress(),
+                        '0xdeadbeef',
+                    ],
+                ),
+            });
+            const sig = await signature(order, chainId, lopv4);
+            await announce(registrator, order);
+
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT))
+                .to.emit(customExtension, 'CustomPostInteractionData')
+                .withArgs('0xdeadbeef');
+        });
+    });
+
+    describe('composition with SimpleSettlement', function () {
+        it('prices the anchored auction chained behind the settlement, exclusivity intact', async function () {
+            const { dai, weth, lopv4, chainId, registrator, auction, settlement } = await loadFixture(deployContractsAndInit);
+
+            const resolverFee = 1000n; // 1% in 1e5
+            const auctionParams = { startTime: 0, duration: 100, initialRateBump: Number(HALF_PERCENT), anchored: true };
+            const auctionTail = ethers.solidityPacked(
+                ['address', 'bytes'],
+                [await auction.getAddress(), buildAnchoredAuctionDetails(auctionParams)],
+            );
+            const exclusivityTail = ethers.solidityPacked(
+                ['address', 'bytes'],
+                [await auction.getAddress(), buildAnchoredExclusivity({ allowedTimeDelay: 30, whitelist: [{ address: taker.address }] })],
+            );
+
+            const order = buildOrder(
+                {
+                    maker: maker.address,
+                    receiver: await settlement.getAddress(),
+                    makerAsset: await dai.getAddress(),
+                    takerAsset: await weth.getAddress(),
+                    makingAmount: MAKING_AMOUNT,
+                    takingAmount: TAKING_AMOUNT,
+                },
+                buildSettlementExtensions({
+                    feeTaker: await settlement.getAddress(),
+                    estimatedTakingAmount: TAKING_AMOUNT,
+                    // A curve that cannot move: no initial bump and no duration, so the settlement multiplies
+                    // by one and the chained auction is the only thing pricing the order.
+                    getterExtraPrefix: buildLegacyAuctionDetails(),
+                    protocolFeeRecipient: otherResolver.address,
+                    resolverFee,
+                    whitelistDiscount: 100,
+                    whitelist: '0x01' + taker.address.slice(-20),
+                    // The settlement's own whitelist is left open, so exclusivity is the chained contract's to enforce.
+                    whitelistPostInteraction: ethers.solidityPacked(
+                        ['uint32', 'uint8', 'uint80', 'uint16'],
+                        [0, 1, BigInt(taker.address) & ((1n << 80n) - 1n), 0],
+                    ),
+                    customMakingGetter: auctionTail,
+                    customTakingGetter: auctionTail,
+                    customPostInteraction: exclusivityTail,
+                }),
+            );
+            const sig = await signature(order, chainId, lopv4);
+            const announcedAt = await announce(registrator, order);
+
+            // The exclusivity chained behind the settlement still bites, though the settlement let the taker in.
+            await time.setNextBlockTimestamp(announcedAt + 20);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT)).to.be.revertedWithCustomError(auction, 'AllowedTimeViolation');
+
+            const fillTime = announcedAt + 60;
+            await time.setNextBlockTimestamp(fillTime);
+            const fillTx = fill(lopv4, order, sig, MAKING_AMOUNT / 2n);
+
+            // The price is the anchored curve with the resolver fee on top, and nothing else.
+            const auctionPrice = takingAmountFor(
+                order,
+                { ...auctionParams, startTime: announcedAt },
+                fillTime,
+                MAKING_AMOUNT / 2n,
+                MAKING_AMOUNT,
+            );
+            const withFee = ceilDiv(auctionPrice * (100000n + resolverFee), 100000n);
+            const feeAmount = withFee - ceilDiv(withFee * 100000n, 100000n + resolverFee);
+            await expect(fillTx).to.changeTokenBalances(weth, [taker, maker, otherResolver], [-withFee, withFee - feeAmount, feeAmount]);
+            await expect(fillTx).to.changeTokenBalances(dai, [taker, maker], [MAKING_AMOUNT / 2n, -MAKING_AMOUNT / 2n]);
+        });
+
+        it('enforces the announcement deadline through a chained settlement', async function () {
+            const { dai, weth, lopv4, chainId, registrator, auction, settlement } = await loadFixture(deployContractsAndInit);
+
+            const auctionParams = { startTime: 0, duration: 100, initialRateBump: 0, anchored: true };
+            const auctionTail = ethers.solidityPacked(
+                ['address', 'bytes'],
+                [await auction.getAddress(), buildAnchoredAuctionDetails(auctionParams)],
+            );
+            const exclusivityTail = ethers.solidityPacked(
+                ['address', 'bytes'],
+                [
+                    await auction.getAddress(),
+                    buildAnchoredExclusivity({
+                        allowedTimeDelay: 0,
+                        announcementDeadlineDelay: 200,
+                        whitelist: [{ address: taker.address }],
+                    }),
+                ],
+            );
+
+            const order = buildOrder(
+                {
+                    maker: maker.address,
+                    receiver: await settlement.getAddress(),
+                    makerAsset: await dai.getAddress(),
+                    takerAsset: await weth.getAddress(),
+                    makingAmount: MAKING_AMOUNT,
+                    takingAmount: TAKING_AMOUNT,
+                },
+                buildSettlementExtensions({
+                    feeTaker: await settlement.getAddress(),
+                    estimatedTakingAmount: TAKING_AMOUNT,
+                    getterExtraPrefix: buildLegacyAuctionDetails(),
+                    whitelistDiscount: 100,
+                    whitelist: '0x01' + taker.address.slice(-20),
+                    whitelistPostInteraction: ethers.solidityPacked(
+                        ['uint32', 'uint8', 'uint80', 'uint16'],
+                        [0, 1, BigInt(taker.address) & ((1n << 80n) - 1n), 0],
+                    ),
+                    customMakingGetter: auctionTail,
+                    customTakingGetter: auctionTail,
+                    customPostInteraction: exclusivityTail,
+                }),
+            );
+            const sig = await signature(order, chainId, lopv4);
+            const announcedAt = await announce(registrator, order);
+
+            // The deadline chained behind the settlement holds even though the settlement let the taker in.
+            await time.setNextBlockTimestamp(announcedAt + 200);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT / 2n))
+                .to.changeTokenBalances(dai, [taker, maker], [MAKING_AMOUNT / 2n, -MAKING_AMOUNT / 2n]);
+
+            await time.setNextBlockTimestamp(announcedAt + 201);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT / 2n))
+                .to.be.revertedWithCustomError(auction, 'AuctionExpired');
+        });
+    });
+
+    describe('parity with the deployed settlement auction', function () {
+        it('prices an unanchored auction exactly as the settlement contract does', async function () {
+            const { dai, weth, lopv4, auction, settlement } = await loadFixture(deployContractsAndInit);
+
+            const params = {
+                gasBumpEstimate: 100000,
+                gasPriceEstimate: 1000,
+                startTime: await time.latest() + 100,
+                duration: 200,
+                initialRateBump: Number(HALF_PERCENT),
+                points: [
+                    { coefficient: Number(HALF_PERCENT * 4n / 5n), delay: 30 },
+                    { coefficient: Number(HALF_PERCENT * 2n / 5n), delay: 30 },
+                ],
+            };
+            const order = await buildAuctionOrder({ dai, weth, auction, auctionDetails: buildAnchoredAuctionDetails(params) });
+            const orderHash = await lopv4.hashOrder(order);
+            const settlementExtraData = ethers.solidityPacked(['bytes', 'bytes'], [buildLegacyAuctionDetails(params), NO_FEE_DATA]);
+            const anchoredExtraData = buildAnchoredAuctionDetails(params);
+
+            // Before the auction, at each of its points, between them, and after it has finished.
+            for (const offset of [-10, 0, 15, 30, 45, 60, 120, 199, 200, 500]) {
+                await time.setNextBlockTimestamp(params.startTime + offset);
+                await hre.network.provider.send('evm_mine');
+
+                for (const amount of [MAKING_AMOUNT, MAKING_AMOUNT / 3n]) {
+                    const args = [order, order.extension, orderHash, taker.address, amount, MAKING_AMOUNT];
+                    expect(await auction.getTakingAmount(...args, anchoredExtraData))
+                        .to.equal(await settlement.getTakingAmount(...args, settlementExtraData));
+                    expect(await auction.getMakingAmount(...args, anchoredExtraData))
+                        .to.equal(await settlement.getMakingAmount(...args, settlementExtraData));
+                }
+            }
+        });
+    });
+});

--- a/test/FusionAnchoredAuction.js
+++ b/test/FusionAnchoredAuction.js
@@ -12,7 +12,9 @@ const {
     buildLegacyAuctionDetails,
     buildAnchoredAuctionDetails,
     buildAnchoredExclusivity,
+    fillPremiumAt,
     takingAmountFor,
+    makingAmountFor,
 } = require('./helpers/anchoredAuction');
 
 const HALF_PERCENT = 50_000n; // 0.5% in 1e7
@@ -162,6 +164,49 @@ describe('FusionAnchoredAuction', function () {
             expect(await weth.balanceOf(maker)).to.equal(expected);
             expect(await dai.balanceOf(taker)).to.equal(MAKING_AMOUNT);
             expect(await registrator.announcedAt(await lopv4.hashOrder(order))).to.equal(await time.latest());
+        });
+
+        it('handles every optional field at once, in both fill directions', async function () {
+            const { dai, weth, lopv4, chainId, registrator, auction } = await loadFixture(deployContractsAndInit);
+
+            const params = {
+                startTime: 0,
+                duration: 100,
+                initialRateBump: Number(HALF_PERCENT),
+                anchored: true,
+                fillPremiums: { initial: Number(HALF_PERCENT), points: [] },
+            };
+            const order = await buildAuctionOrder({
+                dai,
+                weth,
+                auction,
+                auctionDetails: buildAnchoredAuctionDetails(params),
+                // The fill-by deadline rides in the post-interaction blob: an anchored exclusivity with
+                // an empty whitelist is exactly "a deadline without exclusivity".
+                exclusivity: buildAnchoredExclusivity({ allowedTimeDelay: 0, announcementDeadlineDelay: 160, whitelist: [] }),
+            });
+            const sig = await signature(order, chainId, lopv4);
+            const announcedAt = await announce(registrator, order);
+            const resolved = { ...params, startTime: announcedAt };
+
+            // A fill by making amount halfway through the anchored auction, its curve premium on top.
+            const firstFillTime = announcedAt + 50;
+            await time.setNextBlockTimestamp(firstFillTime);
+            const firstExpected = takingAmountFor(order, resolved, firstFillTime, MAKING_AMOUNT / 2n, MAKING_AMOUNT);
+            expect(firstExpected).to.equal(ceilDiv((TAKING_AMOUNT / 2n) * (BASE_POINTS + HALF_PERCENT), BASE_POINTS));
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT / 2n)).to.changeTokenBalances(weth, [taker, maker], [-firstExpected, firstExpected]);
+
+            // A fill by taking amount after the auction, priced through the conservative estimate.
+            const secondFillTime = announcedAt + 120;
+            await time.setNextBlockTimestamp(secondFillTime);
+            const takingAmount = TAKING_AMOUNT / 10n;
+            const secondExpected = makingAmountFor(order, resolved, secondFillTime, takingAmount, MAKING_AMOUNT / 2n);
+            await expect(fill(lopv4, order, sig, takingAmount, { byMakingAmount: false }))
+                .to.changeTokenBalances(dai, [taker, maker], [secondExpected, -secondExpected]);
+
+            // And past the anchored deadline nothing fills at all.
+            await time.setNextBlockTimestamp(announcedAt + 160 + 1);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT / 10n)).to.be.revertedWithCustomError(auction, 'AuctionExpired');
         });
 
         it('gives a slow announcement the same curve a prompt one gets', async function () {
@@ -388,6 +433,314 @@ describe('FusionAnchoredAuction', function () {
             await expect(fill(lopv4, order, sig, MAKING_AMOUNT))
                 .to.emit(customExtension, 'CustomPostInteractionData')
                 .withArgs('0xdeadbeef');
+        });
+    });
+
+    describe('fill-priced by a matrix of rates', function () {
+        // The quote's matrix for 1/10 … 10/10 of the amount, expressed as the premium each size pays over
+        // the rate for the full amount. Deliberately convex, the shape a depth-based quote produces and the
+        // linear rule cannot: small sizes are worth far more per unit than mid sizes.
+        const MATRIX = [400_000, 250_000, 160_000, 105_000, 70_000, 45_000, 26_000, 12_000, 4_000, 0];
+        const FILL_PREMIUMS = {
+            initial: 500_000, // 5% for a vanishing fill
+            // Nine points at each decile up to 9/10; the implied final point is zero premium at a full sweep.
+            points: MATRIX.slice(0, 9).map((premium) => ({ premium, shareDelta: 1000 })),
+        };
+
+        after(async function () {
+            await hre.network.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x1']);
+        });
+
+        async function deployMatrixOrder(extra = {}) {
+            const contracts = await loadFixture(deployContractsAndInit);
+            const { dai, weth, lopv4, chainId, auction } = contracts;
+            const startTime = await time.latest() + 10;
+            const params = { startTime, duration: 100, initialRateBump: Number(HALF_PERCENT), fillPremiums: FILL_PREMIUMS, ...extra };
+            const order = await buildAuctionOrder({ dai, weth, auction, auctionDetails: buildAnchoredAuctionDetails(params) });
+            const sig = await signature(order, chainId, lopv4);
+            return { ...contracts, order, sig, params, afterAuction: startTime + 200 };
+        }
+
+        it('prices every decile exactly at its matrix row', async function () {
+            const { lopv4, auction, order, params, afterAuction } = await deployMatrixOrder();
+
+            await time.setNextBlockTimestamp(afterAuction);
+            await hre.network.provider.send('evm_mine');
+
+            const orderHash = await lopv4.hashOrder(order);
+            const extraData = buildAnchoredAuctionDetails(params);
+            for (let decile = 1; decile <= 10; decile++) {
+                const makingAmount = MAKING_AMOUNT * BigInt(decile) / 10n;
+                const taking = await auction.getTakingAmount(order, order.extension, orderHash, taker.address, makingAmount, MAKING_AMOUNT, extraData);
+                const expectedBump = BigInt(MATRIX[decile - 1]);
+                expect(taking).to.equal(ceilDiv(ceilDiv(TAKING_AMOUNT * BigInt(decile), 10n) * (BASE_POINTS + expectedBump), BASE_POINTS));
+            }
+        });
+
+        it('prices successive fills by their share of what remains', async function () {
+            const { weth, lopv4, order, sig, params, afterAuction } = await deployMatrixOrder();
+
+            // Every fill sees the remainder as a fresh ladder: the first tenth is a 10% slice of a whole
+            // order, the next tenth is a 10/90 slice of what is left, and so on — each priced by its own
+            // share of the remainder rather than by where it lands on the original amount.
+            let fillTime = afterAuction;
+            let remaining = MAKING_AMOUNT;
+            for (let i = 0; i < 3; i++) {
+                await time.setNextBlockTimestamp(fillTime);
+                const expected = takingAmountFor(order, params, fillTime, MAKING_AMOUNT / 10n, remaining);
+                const share = (MAKING_AMOUNT / 10n) * 10000n / remaining;
+                const interpolated = (share - 1000n) * BigInt(MATRIX[1]) + (2000n - share) * BigInt(MATRIX[0]);
+                const premium = i === 0 ? BigInt(MATRIX[0]) : interpolated / 1000n;
+                expect(expected).to.equal(ceilDiv((TAKING_AMOUNT / 10n) * (BASE_POINTS + premium), BASE_POINTS));
+                await expect(fill(lopv4, order, sig, MAKING_AMOUNT / 10n))
+                    .to.changeTokenBalances(weth, [taker, maker], [-expected, expected]);
+                remaining -= MAKING_AMOUNT / 10n;
+                fillTime++;
+            }
+        });
+
+        it('charges a late small fill by its share of the remainder, not its place on the original', async function () {
+            const { weth, lopv4, order, sig, params, afterAuction } = await deployMatrixOrder();
+
+            // With 80% already filled, a fill of 10% of the original order is half of what remains, so it
+            // prices at the 5/10 row — not at the nearly-free 9/10 row its cumulative end would land on.
+            await time.setNextBlockTimestamp(afterAuction);
+            await fill(lopv4, order, sig, MAKING_AMOUNT * 8n / 10n);
+
+            const fillTime = afterAuction + 1;
+            await time.setNextBlockTimestamp(fillTime);
+            const remaining = MAKING_AMOUNT * 2n / 10n;
+            const expected = takingAmountFor(order, params, fillTime, MAKING_AMOUNT / 10n, remaining);
+            expect(expected).to.equal(ceilDiv((TAKING_AMOUNT / 10n) * (BASE_POINTS + BigInt(MATRIX[4])), BASE_POINTS));
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT / 10n))
+                .to.changeTokenBalances(weth, [taker, maker], [-expected, expected]);
+        });
+
+        it('interpolates between matrix rows instead of stepping', async function () {
+            const { weth, lopv4, order, sig, params, afterAuction } = await deployMatrixOrder();
+
+            await time.setNextBlockTimestamp(afterAuction);
+            const makingAmount = MAKING_AMOUNT * 15n / 100n; // halfway between the 1/10 and 2/10 rows
+            const fillTx = fill(lopv4, order, sig, makingAmount);
+
+            const expected = takingAmountFor(order, params, afterAuction, makingAmount, MAKING_AMOUNT);
+            const midRowBump = BigInt(MATRIX[0] + MATRIX[1]) / 2n;
+            expect(expected).to.equal(ceilDiv(ceilDiv(TAKING_AMOUNT * 15n, 100n) * (BASE_POINTS + midRowBump), BASE_POINTS));
+            await expect(fillTx).to.changeTokenBalances(weth, [taker, maker], [-expected, expected]);
+        });
+
+        it('interpolates past the last row toward zero at completion', async function () {
+            const { lopv4, auction, order, params, afterAuction } = await deployMatrixOrder();
+
+            await time.setNextBlockTimestamp(afterAuction);
+            await hre.network.provider.send('evm_mine');
+
+            // The last explicit row sits at 9/10; a fill ending at 95% lands on the implied final segment,
+            // halfway between that row and the zero premium of completion.
+            const makingAmount = MAKING_AMOUNT * 95n / 100n;
+            const taking = await auction.getTakingAmount(
+                order, order.extension, await lopv4.hashOrder(order), taker.address, makingAmount, MAKING_AMOUNT, buildAnchoredAuctionDetails(params),
+            );
+            const halfLastRow = BigInt(MATRIX[8]) / 2n;
+            expect(taking).to.equal(ceilDiv(ceilDiv(TAKING_AMOUNT * 95n, 100n) * (BASE_POINTS + halfLastRow), BASE_POINTS));
+        });
+
+        it('offsets the gas bump from the matrix premium', async function () {
+            const contracts = await loadFixture(deployContractsAndInit);
+            const { dai, weth, lopv4, chainId, auction } = contracts;
+
+            const startTime = await time.latest() + 10;
+            const baseFee = 1000000000n; // 1 gwei, exactly the estimate below
+            const params = {
+                startTime,
+                duration: 100,
+                initialRateBump: Number(HALF_PERCENT),
+                fillPremiums: FILL_PREMIUMS,
+                gasBumpEstimate: Number(HALF_PERCENT * 4n), // 2%
+                gasPriceEstimate: 1000,
+            };
+            const order = await buildAuctionOrder({ dai, weth, auction, auctionDetails: buildAnchoredAuctionDetails(params) });
+            const sig = await signature(order, chainId, lopv4);
+
+            // After the auction the first decile carries the 4% row, and the 2% gas bump comes off it.
+            await hre.network.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x' + baseFee.toString(16)]);
+            await time.setNextBlockTimestamp(startTime + 200);
+            const fillTx = fill(lopv4, order, sig, MAKING_AMOUNT / 10n, { overrides: { gasPrice: baseFee * 2n } });
+
+            const expected = ceilDiv((TAKING_AMOUNT / 10n) * (BASE_POINTS + BigInt(MATRIX[0]) - HALF_PERCENT * 4n), BASE_POINTS);
+            await expect(fillTx).to.changeTokenBalances(weth, [taker, maker], [-expected, expected]);
+        });
+
+        it('never lets any split of the order undercut a single sweep', async function () {
+            const { lopv4, auction, order, params, afterAuction } = await deployMatrixOrder();
+            const singleRow = await deployMatrixOrder({ fillPremiums: { initial: Number(HALF_PERCENT), points: [] } });
+
+            await time.setNextBlockTimestamp(afterAuction + 1000);
+            await hre.network.provider.send('evm_mine');
+
+            // A seeded sweep over random partitions, priced through the contract's own view methods: for
+            // both curve shapes, no way of slicing the order may cost less in total than one full sweep.
+            let seed = 0xdead4351n;
+            const nextRand = (bound) => {
+                seed = (seed * 6364136223846793005n + 1442695040888963407n) & ((1n << 64n) - 1n);
+                return seed % bound;
+            };
+
+            for (const { o, p } of [{ o: order, p: params }, { o: singleRow.order, p: singleRow.params }]) {
+                const orderHash = await lopv4.hashOrder(o);
+                const extraData = buildAnchoredAuctionDetails(p);
+                const sweep = await auction.getTakingAmount(o, o.extension, orderHash, taker.address, MAKING_AMOUNT, MAKING_AMOUNT, extraData);
+
+                for (let trial = 0; trial < 8; trial++) {
+                    const chunks = [];
+                    let remaining = MAKING_AMOUNT;
+                    const parts = 2n + nextRand(4n);
+                    for (let i = 1n; i < parts; i++) {
+                        const chunk = 1n + nextRand(remaining - (parts - i));
+                        chunks.push(chunk);
+                        remaining -= chunk;
+                    }
+                    chunks.push(remaining);
+
+                    let total = 0n;
+                    let left = MAKING_AMOUNT;
+                    for (const chunk of chunks) {
+                        total += await auction.getTakingAmount(o, o.extension, orderHash, taker.address, chunk, left, extraData);
+                        left -= chunk;
+                    }
+                    expect(total, `partition ${chunks.join('+')}`).to.be.greaterThanOrEqual(sweep);
+                }
+            }
+        });
+
+        it('adds the matrix premium on top of the running time curve', async function () {
+            const { weth, lopv4, order, sig, params } = await deployMatrixOrder();
+
+            // Halfway through the auction the time curve still carries half the initial bump, and the
+            // 3/10-sized fill pays its matrix row on top of it.
+            const fillTime = params.startTime + 50;
+            await time.setNextBlockTimestamp(fillTime);
+            const makingAmount = MAKING_AMOUNT * 3n / 10n;
+            const fillTx = fill(lopv4, order, sig, makingAmount);
+
+            const expected = takingAmountFor(order, params, fillTime, makingAmount, MAKING_AMOUNT);
+            expect(expected).to.equal(ceilDiv(ceilDiv(TAKING_AMOUNT * 3n, 10n) * (BASE_POINTS + HALF_PERCENT / 2n + BigInt(MATRIX[2])), BASE_POINTS));
+            await expect(fillTx).to.changeTokenBalances(weth, [taker, maker], [-expected, expected]);
+        });
+
+        it('sweeps the remainder at the plain curve price', async function () {
+            const { weth, lopv4, order, sig, afterAuction } = await deployMatrixOrder();
+
+            await time.setNextBlockTimestamp(afterAuction);
+            await fill(lopv4, order, sig, MAKING_AMOUNT * 3n / 5n);
+
+            // Whatever its absolute size, taking everything that is left costs no premium at all.
+            await time.setNextBlockTimestamp(afterAuction + 10);
+            const remainder = MAKING_AMOUNT * 2n / 5n;
+            await expect(fill(lopv4, order, sig, remainder)).to.changeTokenBalances(
+                weth, [taker, maker], [-TAKING_AMOUNT * 2n / 5n, TAKING_AMOUNT * 2n / 5n],
+            );
+        });
+
+        it('prices a fill by taking amount no better than an exact solution would', async function () {
+            const { dai, lopv4, order, sig, params, afterAuction } = await deployMatrixOrder();
+
+            await time.setNextBlockTimestamp(afterAuction);
+            const takingAmount = TAKING_AMOUNT / 4n;
+            const fillTx = fill(lopv4, order, sig, takingAmount, { byMakingAmount: false });
+
+            const expected = makingAmountFor(order, params, afterAuction, takingAmount, MAKING_AMOUNT);
+            await expect(fillTx).to.changeTokenBalances(dai, [taker, maker], [expected, -expected]);
+
+            const exact = (() => {
+                let amount = expected;
+                for (let i = 0; i < 64; i++) {
+                    const rateBump = amount >= MAKING_AMOUNT ? 0n : fillPremiumAt(amount, MAKING_AMOUNT, FILL_PREMIUMS);
+                    amount = (order.makingAmount * takingAmount / order.takingAmount) * BASE_POINTS / (BASE_POINTS + rateBump);
+                }
+                return amount;
+            })();
+            expect(expected).to.be.lessThanOrEqual(exact);
+        });
+
+        it('works alongside anchoring', async function () {
+            const { weth, lopv4, registrator, order, sig, params } = await deployMatrixOrder({
+                startTime: 0,
+                anchored: true,
+            });
+
+            const announcedAt = await announce(registrator, order);
+            const resolved = { ...params, startTime: announcedAt };
+
+            const fillTime = announcedAt + 120; // past the anchored auction
+            await time.setNextBlockTimestamp(fillTime);
+            const makingAmount = MAKING_AMOUNT / 2n;
+            const expected = takingAmountFor(order, resolved, fillTime, makingAmount, MAKING_AMOUNT);
+            expect(expected).to.equal(ceilDiv((TAKING_AMOUNT / 2n) * (BASE_POINTS + BigInt(MATRIX[4])), BASE_POINTS));
+            await expect(fill(lopv4, order, sig, makingAmount)).to.changeTokenBalances(weth, [taker, maker], [-expected, expected]);
+        });
+
+        it('rejects a matrix whose premium rises along the ladder', async function () {
+            // A hump-shaped matrix: mid-sized fills pay the most. It is encodable, but a rising stretch
+            // makes two fills cheaper than their sum — a taker would be paid to split — so pricing off
+            // such a curve reverts instead.
+            const humpPremiums = {
+                initial: 100_000,
+                points: [
+                    { premium: 400_000, shareDelta: 3000 },
+                    { premium: 50_000, shareDelta: 4000 },
+                ],
+            };
+            const { lopv4, auction, order, sig, afterAuction } = await deployMatrixOrder({ fillPremiums: humpPremiums });
+
+            await time.setNextBlockTimestamp(afterAuction);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT * 3n / 10n))
+                .to.be.revertedWithCustomError(auction, 'NonMonotonicFillCurve');
+
+            // The taking-amount direction walks the same curve and refuses it the same way.
+            await expect(fill(lopv4, order, sig, TAKING_AMOUNT / 10n, { byMakingAmount: false }))
+                .to.be.revertedWithCustomError(auction, 'NonMonotonicFillCurve');
+        });
+
+        it('rejects a rising first row before any interior point is read', async function () {
+            // The initial premium is the curve's whole prefix for a vanishing fill, so a first row above
+            // it is caught on the very first comparison of the walk.
+            const risingPremiums = { initial: 50_000, points: [{ premium: 100_000, shareDelta: 5000 }] };
+            const { lopv4, auction, order, sig, afterAuction } = await deployMatrixOrder({ fillPremiums: risingPremiums });
+
+            await time.setNextBlockTimestamp(afterAuction);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT / 10n))
+                .to.be.revertedWithCustomError(auction, 'NonMonotonicFillCurve');
+        });
+
+        it('validates only the prefix a fill is actually priced on', async function () {
+            // Enforcement is lazy — one comparison per visited point — so a fill priced entirely on the
+            // legal early rows goes through even when a later stretch of the curve is broken, and the
+            // completing fill never reads the curve at all.
+            const brokenTail = {
+                initial: 300_000,
+                points: [
+                    { premium: 200_000, shareDelta: 3000 },
+                    { premium: 400_000, shareDelta: 4000 }, // illegal, but only for fills that reach it
+                ],
+            };
+            const { weth, lopv4, auction, order, sig, params, afterAuction } = await deployMatrixOrder({ fillPremiums: brokenTail });
+
+            await time.setNextBlockTimestamp(afterAuction);
+            const firstAmount = MAKING_AMOUNT * 2n / 10n;
+            const first = takingAmountFor(order, params, afterAuction, firstAmount, MAKING_AMOUNT);
+            await expect(fill(lopv4, order, sig, firstAmount)).to.changeTokenBalances(weth, [taker, maker], [-first, first]);
+
+            // Reaching past the legal prefix hits the rising row and reverts.
+            await time.setNextBlockTimestamp(afterAuction + 10);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT * 3n / 10n))
+                .to.be.revertedWithCustomError(auction, 'NonMonotonicFillCurve');
+
+            // Completing the order short-circuits to the plain auction price without walking the curve.
+            await time.setNextBlockTimestamp(afterAuction + 20);
+            const rest = MAKING_AMOUNT - firstAmount;
+            const completing = takingAmountFor(order, params, afterAuction + 20, rest, rest);
+            await expect(fill(lopv4, order, sig, rest)).to.changeTokenBalances(weth, [taker, maker], [-completing, completing]);
         });
     });
 

--- a/test/helpers/anchoredAuction.js
+++ b/test/helpers/anchoredAuction.js
@@ -1,0 +1,139 @@
+const { ethers } = require('hardhat');
+
+const BASE_POINTS = 10_000_000n; // 100%
+
+const ANCHORED_FLAG = 0x01n;
+// Exclusivity-blob flag namespace: 0x01 is shared with ANCHORED_FLAG.
+const ANNOUNCEMENT_DEADLINE_FLAG = 0x02n;
+
+const ceilDiv = (a, b) => (a + b - 1n) / b;
+
+/** The auction encoding the deployed settlement reads, which is the anchored one without its flags byte. */
+function buildLegacyAuctionDetails({
+    gasBumpEstimate = 0,
+    gasPriceEstimate = 0,
+    startTime = 0,
+    duration = 0,
+    initialRateBump = 0,
+    points = [],
+} = {}) {
+    const types = ['uint24', 'uint32', 'uint32', 'uint24', 'uint24', 'uint8'];
+    const values = [gasBumpEstimate, gasPriceEstimate, startTime, duration, initialRateBump, points.length];
+    for (const { coefficient, delay } of points) {
+        types.push('uint24', 'uint16');
+        values.push(coefficient, delay);
+    }
+    return ethers.solidityPacked(types, values);
+}
+
+/** Zero fees and an empty whitelist, so a settlement getter passes its input straight through. */
+const NO_FEE_DATA = ethers.solidityPacked(['uint16', 'uint8', 'uint16', 'uint8', 'uint8'], [0, 0, 0, 0, 0]);
+
+/** Packs the AuctionDetails blob read by the FusionAnchoredAuction getters. */
+function buildAnchoredAuctionDetails({
+    gasBumpEstimate = 0,
+    gasPriceEstimate = 0,
+    startTime = 0,
+    duration = 0,
+    initialRateBump = 0,
+    anchored = false,
+    points = [],
+} = {}) {
+    let flags = 0n;
+    const types = ['uint8', 'uint24', 'uint32', 'uint32', 'uint24', 'uint24'];
+    const values = [0, gasBumpEstimate, gasPriceEstimate, startTime, duration, initialRateBump];
+
+    if (anchored) {
+        flags |= ANCHORED_FLAG;
+    }
+
+    types.push('uint8');
+    values.push(points.length);
+    for (const { coefficient, delay } of points) {
+        types.push('uint24', 'uint16');
+        values.push(coefficient, delay);
+    }
+    values[0] = flags;
+
+    return ethers.solidityPacked(types, values);
+}
+
+/**
+ * Packs the resolver exclusivity read by FusionAnchoredAuction.postInteraction. `whitelist` entries are
+ * `{ address, delta }`, where `delta` is the wait until the next resolver may fill.
+ */
+function buildAnchoredExclusivity({
+    allowedTime = 0,
+    allowedTimeDelay = undefined,
+    announcementDeadlineDelay = undefined,
+    whitelist = [],
+} = {}) {
+    let flags = 0n;
+    const types = ['uint8', 'uint32'];
+    const values = [0, allowedTime];
+
+    if (allowedTimeDelay !== undefined) {
+        flags |= ANCHORED_FLAG;
+        types.push('uint24');
+        values.push(allowedTimeDelay);
+    }
+    if (announcementDeadlineDelay !== undefined) {
+        flags |= ANNOUNCEMENT_DEADLINE_FLAG;
+        types.push('uint24');
+        values.push(announcementDeadlineDelay);
+    }
+
+    types.push('uint8');
+    values.push(whitelist.length);
+    for (const { address, delta = 0 } of whitelist) {
+        types.push('uint80', 'uint16');
+        values.push(BigInt(address) & ((1n << 80n) - 1n), delta);
+    }
+    values[0] = flags;
+
+    return ethers.solidityPacked(types, values);
+}
+
+/** Mirrors DutchAuctionBase._getAuctionBump. */
+function auctionBumpAt(timestamp, { startTime, duration, initialRateBump, points = [] }) {
+    const now = BigInt(timestamp);
+    const start = BigInt(startTime);
+    const finish = start + BigInt(duration);
+    if (now <= start) return BigInt(initialRateBump);
+    if (now >= finish) return 0n;
+
+    let currentPointTime = start;
+    let currentRateBump = BigInt(initialRateBump);
+    for (const { coefficient, delay } of points) {
+        const nextRateBump = BigInt(coefficient);
+        const nextPointTime = currentPointTime + BigInt(delay);
+        if (now <= nextPointTime) {
+            return ((now - currentPointTime) * nextRateBump + (nextPointTime - now) * currentRateBump) / (nextPointTime - currentPointTime);
+        }
+        currentRateBump = nextRateBump;
+        currentPointTime = nextPointTime;
+    }
+    return (finish - now) * currentRateBump / (finish - currentPointTime);
+}
+
+/** Mirrors the gas bump offset from the rate bump. */
+function applyGasBump(rateBump, gasBump) {
+    return rateBump > gasBump ? rateBump - gasBump : 0n;
+}
+
+/** Taking amount a fill by making amount is priced at. */
+function takingAmountFor(order, auction, timestamp, makingAmount, remainingMakingAmount, gasBump = 0n) {
+    const rateBump = applyGasBump(auctionBumpAt(timestamp, auction), gasBump);
+    const unbumped = ceilDiv(order.takingAmount * makingAmount, order.makingAmount);
+    return ceilDiv(unbumped * (BASE_POINTS + rateBump), BASE_POINTS);
+}
+
+module.exports = {
+    BASE_POINTS,
+    NO_FEE_DATA,
+    ceilDiv,
+    buildLegacyAuctionDetails,
+    buildAnchoredAuctionDetails,
+    buildAnchoredExclusivity,
+    takingAmountFor,
+};

--- a/test/helpers/anchoredAuction.js
+++ b/test/helpers/anchoredAuction.js
@@ -3,6 +3,7 @@ const { ethers } = require('hardhat');
 const BASE_POINTS = 10_000_000n; // 100%
 
 const ANCHORED_FLAG = 0x01n;
+const FILL_CURVE_FLAG = 0x02n;
 // Exclusivity-blob flag namespace: 0x01 is shared with ANCHORED_FLAG.
 const ANNOUNCEMENT_DEADLINE_FLAG = 0x02n;
 
@@ -37,6 +38,7 @@ function buildAnchoredAuctionDetails({
     duration = 0,
     initialRateBump = 0,
     anchored = false,
+    fillPremiums = undefined,
     points = [],
 } = {}) {
     let flags = 0n;
@@ -45,6 +47,15 @@ function buildAnchoredAuctionDetails({
 
     if (anchored) {
         flags |= ANCHORED_FLAG;
+    }
+    if (fillPremiums !== undefined) {
+        flags |= FILL_CURVE_FLAG;
+        types.push('uint24', 'uint8');
+        values.push(fillPremiums.initial, fillPremiums.points.length);
+        for (const { premium, shareDelta } of fillPremiums.points) {
+            types.push('uint24', 'uint16');
+            values.push(premium, shareDelta);
+        }
     }
 
     types.push('uint8');
@@ -116,6 +127,33 @@ function auctionBumpAt(timestamp, { startTime, duration, initialRateBump, points
     return (finish - now) * currentRateBump / (finish - currentPointTime);
 }
 
+const SHARE_BASE = 10_000n;
+
+/** Mirrors FusionAnchoredAuction._fillPremium: the fill's share of what remains, on a fresh ladder. */
+function fillPremiumAt(makingAmount, remainingMakingAmount, { initial, points = [] }) {
+    let currentPremium = BigInt(initial);
+    const share = makingAmount * SHARE_BASE / remainingMakingAmount;
+    if (share === 0n) return currentPremium;
+
+    let currentShare = 0n;
+    for (const { premium, shareDelta } of points) {
+        const nextPremium = BigInt(premium);
+        const nextShare = currentShare + BigInt(shareDelta);
+        if (share <= nextShare) {
+            return ((share - currentShare) * nextPremium + (nextShare - share) * currentPremium) / (nextShare - currentShare);
+        }
+        currentPremium = nextPremium;
+        currentShare = nextShare;
+    }
+    return (SHARE_BASE - share) * currentPremium / (SHARE_BASE - currentShare);
+}
+
+/** Mirrors FusionAnchoredAuction._rateBumpForFill. */
+function rateBumpForFill(rateBump, auction, makingAmount, remainingMakingAmount) {
+    if (!auction.fillPremiums || makingAmount >= remainingMakingAmount) return rateBump;
+    return rateBump + fillPremiumAt(makingAmount, remainingMakingAmount, auction.fillPremiums);
+}
+
 /** Mirrors the gas bump offset from the rate bump. */
 function applyGasBump(rateBump, gasBump) {
     return rateBump > gasBump ? rateBump - gasBump : 0n;
@@ -123,9 +161,23 @@ function applyGasBump(rateBump, gasBump) {
 
 /** Taking amount a fill by making amount is priced at. */
 function takingAmountFor(order, auction, timestamp, makingAmount, remainingMakingAmount, gasBump = 0n) {
-    const rateBump = applyGasBump(auctionBumpAt(timestamp, auction), gasBump);
+    const rateBump = applyGasBump(rateBumpForFill(auctionBumpAt(timestamp, auction), auction, makingAmount, remainingMakingAmount), gasBump);
     const unbumped = ceilDiv(order.takingAmount * makingAmount, order.makingAmount);
     return ceilDiv(unbumped * (BASE_POINTS + rateBump), BASE_POINTS);
+}
+
+/** Making amount a fill by taking amount is priced at, including the conservative fill-share estimate. */
+function makingAmountFor(order, auction, timestamp, takingAmount, remainingMakingAmount, gasBump = 0n) {
+    const bump = auctionBumpAt(timestamp, auction);
+    const unbumped = order.makingAmount * takingAmount / order.takingAmount;
+    let rateBump = bump;
+    if (auction.fillPremiums) {
+        // Premium curves are enforced non-increasing, so the initial premium is the worst one.
+        const worstRateBump = bump + BigInt(auction.fillPremiums.initial);
+        const estimate = unbumped * BASE_POINTS / (BASE_POINTS + applyGasBump(worstRateBump, gasBump));
+        rateBump = rateBumpForFill(bump, auction, estimate, remainingMakingAmount);
+    }
+    return unbumped * BASE_POINTS / (BASE_POINTS + applyGasBump(rateBump, gasBump));
 }
 
 module.exports = {
@@ -135,5 +187,7 @@ module.exports = {
     buildLegacyAuctionDetails,
     buildAnchoredAuctionDetails,
     buildAnchoredExclusivity,
+    fillPremiumAt,
     takingAmountFor,
+    makingAmountFor,
 };


### PR DESCRIPTION
## Change Summary
**What does this PR change?**

Adds the announcement-anchored Dutch auction as a standalone, per-order opt-in extension, plus fill-size-dependent pricing over the order's volume ladder. The first commit is a pure move-only extraction of the existing auction math (`_getRateBump`/`_getAuctionBump` and their constants) from `SimpleSettlement` into an abstract `DutchAuctionBase` — bodies byte-identical, visibility `private` → `internal virtual` — so the feature itself reads as a small diff on top of code this repo already ships.

Why: a Fusion auction starts at an absolute timestamp baked into the order at build time, so a maker that signs slowly (a multisig collecting signatures) misses its own window and degrades to the floor price. Anchoring starts the schedule from the moment the order was first announced on-chain instead. This executes the team's agreed split of 1inch/limit-order-protocol#430 (the auction mechanics belong in this repo); the anchor is the write-once `announcedAt` recorded by the registrator in 1inch/limit-order-protocol#435.

![Taking amount for a full fill over wall-clock time. Baked at build time the curve reaches the floor at 30 minutes, before a 45-minute multisig can sign, and then sits at the floor indefinitely. Anchored, the order is unfillable until announced at 45 minutes, then runs the same full curve, and its floor tail is ended by the announcement deadline at 80 minutes.](https://cursor.com/artifacts/c/art-ae420461-3257-4172-bddd-ee243f7c98e7)

*The scenario this exists for: a Safe taking 45 minutes to co-sign. Today the curve decays while owners are still signing and the order is at the floor by the time it can be filled — a free option for resolvers. Anchored, it is unfillable until announced, then runs the same full curve an EOA gets; the optional announcement deadline bounds how long it stays fillable at the floor. The initial bump is exaggerated to 5% for legibility.*

**Related Issue/Ticket:** PT1-724; review thread and reference implementation: 1inch/limit-order-protocol#430.

## Testing & Verification
**How was this tested?**
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing (describe steps)
- [ ] Verified on staging

- Baseline suite: 115 passing. After the extraction commit the untouched existing suite still passes exactly 115 — the refactor is behaviorally identical by test evidence, not just by eyeball.
- 16 new tests for the anchored extension: pricing parity with the settlement's own auction, anchored-start cases (stale built start ignored, later built start wins, same-block announce-and-fill), unannounced anchored order reverting, exclusivity windows (anchored window held open, staggered resolvers, empty whitelist, non-whitelisted takers waiting out every window), the announcement deadline exact at its boundary, deadline-without-anchor failing closed, and chaining behind `SimpleSettlement`.
- 15 new tests for the ladder: matrix rows hit exactly on a fresh order, interpolation between and past rows, successive fills repriced on the remainder, zero-premium completion, lazy monotonicity rejection, a seeded superadditivity sweep (random partitions never undercut a single sweep, priced through the contract's own views), and the gas-bump interaction. Total: 146 passing.
- New contracts at 100% line coverage; `yarn lint` fully green — this branch carries a one-commit fix for the two pre-existing `scripts/` lint errors (`space-before-function-paren` in `mint-kyc.js` and `transfer-ownership.js`) that had master's lint job red.

## Risk Assessment
**Risk Level:**
- [x] **Low** - Minor changes, no operational impact
- [ ] **Medium** - Moderate changes, limited impact, standard rollback available
- [ ] **High** - Significant changes, potential operational impact, complex rollback

**Risks & Impact**
- No deployed-contract changes and no redeploys. `SimpleSettlement`'s source is refactored (inheritance only; its untouched test suite pins identical behavior), and deployed settlement instances are unaffected. The extension is a new, separately deployed contract that orders opt into through their extension bytes.
- Deploy sequencing: the extension's constructor takes the registrator address, so the updated `OrderRegistrator` from 1inch/limit-order-protocol#435 deploys first per chain; `config/constants` carries the placeholder where those addresses land.
- Tests announce through a minimal write-once mock (`OrderRegistratorMock`) because the pinned `@1inch/limit-order-protocol-contract` 4.3.2 predates the `announcedAt` view; the production interface is declared locally as one view function.

## What's inside

Every feature is opt-in per order via a flags byte; with no flags set, pricing matches the settlement's existing auction exactly.

- **Anchored start** (auction flag `0x01`): auction start = `max(announcedAt, builtStartTime)`. An anchored order that was never announced reverts `OrderNotAnnounced`; a re-announcement can never move the anchor (write-once at the registrator).
- **Announcement-anchored resolver exclusivity + deadline** (post-interaction blob): whitelist windows measured from the announcement instead of absolute time, and an optional fill-by deadline — fillable at exactly `announcedAt + delay`, reverting `AuctionExpired` strictly after. The deadline flag without the anchored flag reverts `InvalidFlagCombination`. It lives in the post-interaction because a post-interaction is not skippable by getter mis-assembly.
- **Volume-ladder fill pricing** (auction flag `0x02`): a fill pays a premium by its share of the remaining amount (1e4 base) over a piecewise-linear curve — a tenth of what is left prices at the 1/10 row whether it is the first fill or the fifth — and whoever completes the order pays no premium at all. The curve is enforced non-increasing lazily during the walk (`NonMonotonicFillCurve`), so splitting always costs takers more than sweeping. In the making-amount direction the share is estimated at the worst rate bump and repriced, so the estimate never exceeds the exact solution.

### Visualizations

![The fill curve over the volume ladder: the quote matrix hit exactly at each row and interpolated in between, next to the single-row schedule with no interior points — both falling to zero for a fill that takes the whole remainder](https://cursor.com/artifacts/c/art-80ed685a-e7fc-40e3-b862-e639a15df76c)

*One encoding for every schedule, drawn over the share of the remainder a fill takes: the matrix hits each quote row exactly at its rung and interpolates in between; a curve with no interior points (dashed) is the one-parameter schedule. Both end at zero, so completion is never penalized.*

![Bar chart comparing the total premium paid for one sweep, two halves, four quarters, ten tenths and a 30/30/40 split, under the quote matrix and a single-row curve](https://cursor.com/artifacts/c/art-37e15c63-ff59-4a5d-9f8e-8e3eb06a07c6)

*Splitting always costs the takers more than one sweep, and the fill that completes the order pays no premium at all — superadditivity, pinned in this PR by the seeded random-partition test priced through the contract's own views.*

![Two panels for a low-liquidity pair. Left: the value a resolver keeps as a share of the fill, against fill size — 2.66 percent for a tenth-sized fill under flat pricing, zero at every size under the volume ladder. Right: extra proceeds for the maker by fill pattern, up to plus 2.74 percent against a resolver that cherry-picks ten percent and stops](https://cursor.com/artifacts/c/art-ffb4fa49-84a2-4649-9423-8774a4f4568a)

*Where the ladder earns its keep: on a thin book where a full sweep costs 4% in price impact, a resolver filling a tenth today keeps 2.66% of that fill purely because the slice was small; the ladder prices the slice at its own size and the value stays with the maker. Sweeping is unaffected. The impact model and its assumptions are documented in 1inch/limit-order-protocol#430; the matrix there is set to the full modelled edge, so production rows should sit below it to leave partial fills some margin.*

### Measured costs, from the reference implementation

![Two panels of measured gas. Left: cost of one fill — against the live mainnet Settlement, 92,089 gas today versus 107,410 with the anchored auction chained behind it, plus 15,321. Right: new per-order costs — announcing an order costs 31,132 gas.](https://cursor.com/artifacts/c/art-17ae953a-9cd0-45bf-8111-98b699ae5ae6)

*Every number is `receipt.gasUsed` from real fills of the reference implementation (1inch/limit-order-protocol#430 — identical pricing logic and the same chained-call structure as this PR), measured against both the live mainnet Settlement on a fork and a local mirror: chaining the anchored auction behind the deployed settlement costs about 15.0–15.3k gas per fill, the fill ladder adds 1,365 gas to a partial fill and 558 to a completing one, and the per-order announcement costs 31,132 gas for a lean order. The right panel's `DelegatedMaker` bar belongs to a separate, currently parked proposal — not this PR. Reproduction harnesses live on the reference branch: `scripts/gas-comparison.js`, `scripts/gas-comparison-fork.js`, `scripts/price-impact.js`, `scripts/fill-curve-data.js`.*

## Notes for reviewers

- Review commit-by-commit: `06fe413` is pure code motion, `0068ea0` is the anchored MVP, `13918b3` is the ladder (originally the stacked PR #224, merged into this branch, so this PR carries the complete feature).
- Fixed-point scaling uses `Math.mulDiv` to match the extracted base — a deliberate deviation from the reference implementation's 2^128 fast paths.
- Measured economics (fill-ladder charts, splitting superadditivity, thin-book price impact) and the gas story are in 1inch/limit-order-protocol#430, which remains the reference implementation this port mirrors.
