### PR TITLE
feat: price each fill by its share of the remainder

### DIFF
--- a/contracts/extensions/FusionAnchoredAuction.sol
+++ b/contracts/extensions/FusionAnchoredAuction.sol
@@ -12,7 +12,8 @@ import { IOrderRegistrator } from "../interfaces/IOrderRegistrator.sol";
 
 /**
  * @title FusionAnchoredAuction
- * @notice Dutch auction whose schedule may be anchored to the moment an order was announced on-chain.
+ * @notice Dutch auction whose schedule may be anchored to the moment an order was announced on-chain,
+ * and whose price may depend on how much of the order a taker fills.
  * @dev A standalone amount getter and post-interaction, referenced by address from the order extension —
  * directly or chained behind an already deployed settlement contract — so it requires no settlement
  * redeployment. Each feature is opt-in per order through a flags byte; with no flags set the pricing
@@ -22,8 +23,13 @@ import { IOrderRegistrator } from "../interfaces/IOrderRegistrator.sol";
 contract FusionAnchoredAuction is AmountGetterBase, DutchAuctionBase, IPostInteraction {
     /// @dev Measure from `announcedAt` instead of the built timestamp alone. Shared by both blobs.
     bytes1 private constant _ANCHORED_FLAG = 0x01;
+    /// @dev Auction-details flag: price a fill by a piecewise premium curve over the order's volume ladder.
+    bytes1 private constant _FILL_CURVE_FLAG = 0x02;
     /// @dev Exclusivity-blob flag: stop fills after `announcedAt` plus the deadline delay.
     bytes1 private constant _ANNOUNCEMENT_DEADLINE_FLAG = 0x02;
+
+    /// @dev Fill shares are measured in 1e4.
+    uint256 private constant _SHARE_BASE = 10_000;
 
     /// @dev The order relies on its announcement but was never announced.
     error OrderNotAnnounced();
@@ -31,6 +37,8 @@ contract FusionAnchoredAuction is AmountGetterBase, DutchAuctionBase, IPostInter
     error AuctionExpired();
     /// @dev The taker may not fill the order yet.
     error AllowedTimeViolation();
+    /// @dev A premium that rises along the volume ladder would reward splitting a fill.
+    error NonMonotonicFillCurve();
     /// @dev A flag was set without the flag it depends on.
     error InvalidFlagCombination();
 
@@ -116,7 +124,10 @@ contract FusionAnchoredAuction is AmountGetterBase, DutchAuctionBase, IPostInter
     }
 
     /**
-     * @dev Adds anchored dutch auction capabilities to the getter.
+     * @dev Adds anchored dutch auction capabilities to the getter. The fill share is not known here —
+     * it is the value being computed — so it is estimated at the worst rate bump the auction can produce
+     * and the price is recomputed from that estimate. The estimate can only understate the share and
+     * therefore only overstate the rate bump, so the result never exceeds an exact solution.
      */
     function _getMakingAmount(
         IOrderMixin.Order calldata order,
@@ -127,16 +138,22 @@ contract FusionAnchoredAuction is AmountGetterBase, DutchAuctionBase, IPostInter
         uint256 remainingMakingAmount,
         bytes calldata extraData
     ) internal view override returns (uint256) {
-        (uint256 rateBump, bytes calldata tail) = _parseRateBump(extraData, orderHash);
-        return Math.mulDiv(
-            super._getMakingAmount(order, extension, orderHash, taker, takingAmount, remainingMakingAmount, tail),
-            _BASE_POINTS,
-            _BASE_POINTS + rateBump
-        );
+        (uint256 auctionBump, uint256 gasBump, bytes calldata fillCurve, bytes calldata tail) = _parseAuctionDetails(extraData, orderHash);
+        uint256 unbumpedAmount = super._getMakingAmount(order, extension, orderHash, taker, takingAmount, remainingMakingAmount, tail);
+
+        uint256 rateBump = auctionBump;
+        if (fillCurve.length != 0) {
+            // The curve is enforced non-increasing, so its initial premium is the worst it can price at.
+            uint256 worstRateBump = auctionBump + uint24(bytes3(fillCurve[0:3]));
+            uint256 estimatedMakingAmount = Math.mulDiv(unbumpedAmount, _BASE_POINTS, _BASE_POINTS + _applyGasBump(worstRateBump, gasBump));
+            rateBump = _rateBumpForFill(auctionBump, fillCurve, estimatedMakingAmount, remainingMakingAmount);
+        }
+
+        return Math.mulDiv(unbumpedAmount, _BASE_POINTS, _BASE_POINTS + _applyGasBump(rateBump, gasBump));
     }
 
     /**
-     * @dev Adds anchored dutch auction capabilities to the getter.
+     * @dev Adds anchored dutch auction capabilities to the getter, where the fill share is known exactly.
      */
     function _getTakingAmount(
         IOrderMixin.Order calldata order,
@@ -147,7 +164,8 @@ contract FusionAnchoredAuction is AmountGetterBase, DutchAuctionBase, IPostInter
         uint256 remainingMakingAmount,
         bytes calldata extraData
     ) internal view override returns (uint256) {
-        (uint256 rateBump, bytes calldata tail) = _parseRateBump(extraData, orderHash);
+        (uint256 auctionBump, uint256 gasBump, bytes calldata fillCurve, bytes calldata tail) = _parseAuctionDetails(extraData, orderHash);
+        uint256 rateBump = _applyGasBump(_rateBumpForFill(auctionBump, fillCurve, makingAmount, remainingMakingAmount), gasBump);
         return Math.mulDiv(
             super._getTakingAmount(order, extension, orderHash, taker, makingAmount, remainingMakingAmount, tail),
             _BASE_POINTS + rateBump,
@@ -157,7 +175,7 @@ contract FusionAnchoredAuction is AmountGetterBase, DutchAuctionBase, IPostInter
     }
 
     /**
-     * @dev Parses the auction rate bump, resolving an anchored start from the announcement.
+     * @dev Parses the auction, resolving everything that does not depend on the fill size.
      * @param auctionDetails AuctionDetails is a tightly packed struct of the following format:
      * ```
      * struct AuctionDetails {
@@ -167,17 +185,26 @@ contract FusionAnchoredAuction is AmountGetterBase, DutchAuctionBase, IPostInter
      *     bytes4 auctionStartTime;
      *     bytes3 auctionDuration;
      *     bytes3 initialRateBump;
+     *     FillCurve fillCurve;           // present when the fill curve flag is set
      *     bytes1 pointsCount;
      *     (bytes3,bytes2)[N] pointsAndTimeDeltas;
+     * }
+     *
+     * struct FillCurve {
+     *     bytes3 initialFillPremium;
+     *     bytes1 fillPointsCount;
+     *     (bytes3,bytes2)[M] premiumsAndShareDeltas;
      * }
      * ```
      * An anchored auction starts at the later of its announcement and the built start time, so a
      * stale built start is ignored while a deliberately delayed one still holds.
      * @param orderHash The hash of the order, the key the announcement is recorded under.
-     * @return rateBump The rate bump at the current time.
-     * @return Remaining calldata after parsing auction data.
+     * @return auctionBump The time curve's rate bump at the current moment.
+     * @return gasBump The rate-bump offset estimating the taker's transaction costs.
+     * @return fillCurve The premium curve over fill shares, empty when the order does not carry one.
+     * @return tail Remaining calldata after the auction.
      */
-    function _parseRateBump(bytes calldata auctionDetails, bytes32 orderHash) private view returns (uint256, bytes calldata) {
+    function _parseAuctionDetails(bytes calldata auctionDetails, bytes32 orderHash) private view returns (uint256 auctionBump, uint256 gasBump, bytes calldata fillCurve, bytes calldata tail) {
         unchecked {
             bytes1 flags = auctionDetails[0];
             uint256 gasBumpEstimate = uint24(bytes3(auctionDetails[1:4]));
@@ -185,15 +212,80 @@ contract FusionAnchoredAuction is AmountGetterBase, DutchAuctionBase, IPostInter
             uint256 auctionStartTime = uint32(bytes4(auctionDetails[8:12]));
             uint256 auctionDuration = uint24(bytes3(auctionDetails[12:15]));
             uint256 initialRateBump = uint24(bytes3(auctionDetails[15:18]));
+            uint256 offset = 18;
 
             if (flags & _ANCHORED_FLAG != 0) {
                 uint256 anchoredStartTime = _announcedAt(orderHash);
                 if (anchoredStartTime > auctionStartTime) auctionStartTime = anchoredStartTime;
             }
 
-            uint256 gasBump = gasBumpEstimate == 0 || gasPriceEstimate == 0 ? 0 : gasBumpEstimate * block.basefee / gasPriceEstimate / _GAS_PRICE_BASE;
-            (uint256 auctionBump, bytes calldata tail) = _getAuctionBump(auctionStartTime, auctionStartTime + auctionDuration, initialRateBump, auctionDetails[18:]);
-            return (auctionBump > gasBump ? auctionBump - gasBump : 0, tail);
+            if (flags & _FILL_CURVE_FLAG != 0) {
+                uint256 fillCurveLength = 4 + 5 * uint256(uint8(auctionDetails[offset + 3]));
+                fillCurve = auctionDetails[offset:offset + fillCurveLength];
+                offset += fillCurveLength;
+            } else {
+                fillCurve = auctionDetails[0:0];
+            }
+
+            gasBump = gasBumpEstimate == 0 || gasPriceEstimate == 0 ? 0 : gasBumpEstimate * block.basefee / gasPriceEstimate / _GAS_PRICE_BASE;
+            (auctionBump, tail) = _getAuctionBump(auctionStartTime, auctionStartTime + auctionDuration, initialRateBump, auctionDetails[offset:]);
+        }
+    }
+
+    /**
+     * @dev The rate bump a fill is priced at: the time curve's bump, plus the fill premium for a fill
+     * that leaves part of the order behind. A completing fill never reads the curve.
+     */
+    function _rateBumpForFill(uint256 auctionBump, bytes calldata fillCurve, uint256 makingAmount, uint256 remainingMakingAmount) private pure returns (uint256) {
+        unchecked {
+            if (fillCurve.length == 0 || makingAmount >= remainingMakingAmount) return auctionBump;
+            return auctionBump + _fillPremium(makingAmount, remainingMakingAmount, fillCurve);
+        }
+    }
+
+    /**
+     * @dev Reads the premium a fill pays from the piecewise curve over the order's volume ladder.
+     * A fill is priced by its own share of what remains, measured in 1e4 of `remainingMakingAmount`,
+     * so every fill sees the remainder as a fresh ladder and a completing fill pays no premium at all.
+     * The curve starts at the initial premium for a vanishing fill, is interpolated linearly between
+     * points, and ends at an implied final point of zero premium at the full remainder. The premium
+     * must not increase along the ladder — a rising stretch would pay takers to split a fill — and the
+     * walk enforces that lazily, one comparison per visited point.
+     * @param makingAmount The making amount of this fill, strictly below the remainder.
+     * @param remainingMakingAmount The making amount left on the order before this fill.
+     * @param fillCurve The packed curve: 3 bytes initial premium, 1 byte count, (3 bytes, 2 bytes) points.
+     * @return The premium this fill pays on top of the time curve's rate bump.
+     */
+    function _fillPremium(uint256 makingAmount, uint256 remainingMakingAmount, bytes calldata fillCurve) private pure returns (uint256) {
+        unchecked {
+            uint256 currentPremium = uint24(bytes3(fillCurve[0:3]));
+            uint256 share = Math.mulDiv(makingAmount, _SHARE_BASE, remainingMakingAmount);
+            if (share == 0) return currentPremium;
+
+            uint256 currentShare = 0;
+            uint256 pointsCount = uint8(fillCurve[3]);
+            bytes calldata points = fillCurve[4:];
+            for (uint256 i = 0; i < pointsCount; i++) {
+                uint256 nextPremium = uint24(bytes3(points[:3]));
+                if (nextPremium > currentPremium) revert NonMonotonicFillCurve();
+                uint256 nextShare = currentShare + uint16(bytes2(points[3:5]));
+                if (share <= nextShare) {
+                    return ((share - currentShare) * nextPremium + (nextShare - share) * currentPremium) / (nextShare - currentShare);
+                }
+                currentPremium = nextPremium;
+                currentShare = nextShare;
+                points = points[5:];
+            }
+            return (_SHARE_BASE - share) * currentPremium / (_SHARE_BASE - currentShare);
+        }
+    }
+
+    /**
+     * @dev Offsets the estimated transaction costs from the auction rate bump.
+     */
+    function _applyGasBump(uint256 rateBump, uint256 gasBump) private pure returns (uint256) {
+        unchecked {
+            return rateBump > gasBump ? rateBump - gasBump : 0;
         }
     }
 

--- a/test/FusionAnchoredAuction.js
+++ b/test/FusionAnchoredAuction.js
@@ -12,7 +12,9 @@ const {
     buildLegacyAuctionDetails,
     buildAnchoredAuctionDetails,
     buildAnchoredExclusivity,
+    fillPremiumAt,
     takingAmountFor,
+    makingAmountFor,
 } = require('./helpers/anchoredAuction');
 
 const HALF_PERCENT = 50_000n; // 0.5% in 1e7
@@ -162,6 +164,49 @@ describe('FusionAnchoredAuction', function () {
             expect(await weth.balanceOf(maker)).to.equal(expected);
             expect(await dai.balanceOf(taker)).to.equal(MAKING_AMOUNT);
             expect(await registrator.announcedAt(await lopv4.hashOrder(order))).to.equal(await time.latest());
+        });
+
+        it('handles every optional field at once, in both fill directions', async function () {
+            const { dai, weth, lopv4, chainId, registrator, auction } = await loadFixture(deployContractsAndInit);
+
+            const params = {
+                startTime: 0,
+                duration: 100,
+                initialRateBump: Number(HALF_PERCENT),
+                anchored: true,
+                fillPremiums: { initial: Number(HALF_PERCENT), points: [] },
+            };
+            const order = await buildAuctionOrder({
+                dai,
+                weth,
+                auction,
+                auctionDetails: buildAnchoredAuctionDetails(params),
+                // The fill-by deadline rides in the post-interaction blob: an anchored exclusivity with
+                // an empty whitelist is exactly "a deadline without exclusivity".
+                exclusivity: buildAnchoredExclusivity({ allowedTimeDelay: 0, announcementDeadlineDelay: 160, whitelist: [] }),
+            });
+            const sig = await signature(order, chainId, lopv4);
+            const announcedAt = await announce(registrator, order);
+            const resolved = { ...params, startTime: announcedAt };
+
+            // A fill by making amount halfway through the anchored auction, its curve premium on top.
+            const firstFillTime = announcedAt + 50;
+            await time.setNextBlockTimestamp(firstFillTime);
+            const firstExpected = takingAmountFor(order, resolved, firstFillTime, MAKING_AMOUNT / 2n, MAKING_AMOUNT);
+            expect(firstExpected).to.equal(ceilDiv((TAKING_AMOUNT / 2n) * (BASE_POINTS + HALF_PERCENT), BASE_POINTS));
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT / 2n)).to.changeTokenBalances(weth, [taker, maker], [-firstExpected, firstExpected]);
+
+            // A fill by taking amount after the auction, priced through the conservative estimate.
+            const secondFillTime = announcedAt + 120;
+            await time.setNextBlockTimestamp(secondFillTime);
+            const takingAmount = TAKING_AMOUNT / 10n;
+            const secondExpected = makingAmountFor(order, resolved, secondFillTime, takingAmount, MAKING_AMOUNT / 2n);
+            await expect(fill(lopv4, order, sig, takingAmount, { byMakingAmount: false }))
+                .to.changeTokenBalances(dai, [taker, maker], [secondExpected, -secondExpected]);
+
+            // And past the anchored deadline nothing fills at all.
+            await time.setNextBlockTimestamp(announcedAt + 160 + 1);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT / 10n)).to.be.revertedWithCustomError(auction, 'AuctionExpired');
         });
 
         it('gives a slow announcement the same curve a prompt one gets', async function () {
@@ -388,6 +433,314 @@ describe('FusionAnchoredAuction', function () {
             await expect(fill(lopv4, order, sig, MAKING_AMOUNT))
                 .to.emit(customExtension, 'CustomPostInteractionData')
                 .withArgs('0xdeadbeef');
+        });
+    });
+
+    describe('fill-priced by a matrix of rates', function () {
+        // The quote's matrix for 1/10 … 10/10 of the amount, expressed as the premium each size pays over
+        // the rate for the full amount. Deliberately convex, the shape a depth-based quote produces and the
+        // linear rule cannot: small sizes are worth far more per unit than mid sizes.
+        const MATRIX = [400_000, 250_000, 160_000, 105_000, 70_000, 45_000, 26_000, 12_000, 4_000, 0];
+        const FILL_PREMIUMS = {
+            initial: 500_000, // 5% for a vanishing fill
+            // Nine points at each decile up to 9/10; the implied final point is zero premium at a full sweep.
+            points: MATRIX.slice(0, 9).map((premium) => ({ premium, shareDelta: 1000 })),
+        };
+
+        after(async function () {
+            await hre.network.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x1']);
+        });
+
+        async function deployMatrixOrder(extra = {}) {
+            const contracts = await loadFixture(deployContractsAndInit);
+            const { dai, weth, lopv4, chainId, auction } = contracts;
+            const startTime = await time.latest() + 10;
+            const params = { startTime, duration: 100, initialRateBump: Number(HALF_PERCENT), fillPremiums: FILL_PREMIUMS, ...extra };
+            const order = await buildAuctionOrder({ dai, weth, auction, auctionDetails: buildAnchoredAuctionDetails(params) });
+            const sig = await signature(order, chainId, lopv4);
+            return { ...contracts, order, sig, params, afterAuction: startTime + 200 };
+        }
+
+        it('prices every decile exactly at its matrix row', async function () {
+            const { lopv4, auction, order, params, afterAuction } = await deployMatrixOrder();
+
+            await time.setNextBlockTimestamp(afterAuction);
+            await hre.network.provider.send('evm_mine');
+
+            const orderHash = await lopv4.hashOrder(order);
+            const extraData = buildAnchoredAuctionDetails(params);
+            for (let decile = 1; decile <= 10; decile++) {
+                const makingAmount = MAKING_AMOUNT * BigInt(decile) / 10n;
+                const taking = await auction.getTakingAmount(order, order.extension, orderHash, taker.address, makingAmount, MAKING_AMOUNT, extraData);
+                const expectedBump = BigInt(MATRIX[decile - 1]);
+                expect(taking).to.equal(ceilDiv(ceilDiv(TAKING_AMOUNT * BigInt(decile), 10n) * (BASE_POINTS + expectedBump), BASE_POINTS));
+            }
+        });
+
+        it('prices successive fills by their share of what remains', async function () {
+            const { weth, lopv4, order, sig, params, afterAuction } = await deployMatrixOrder();
+
+            // Every fill sees the remainder as a fresh ladder: the first tenth is a 10% slice of a whole
+            // order, the next tenth is a 10/90 slice of what is left, and so on — each priced by its own
+            // share of the remainder rather than by where it lands on the original amount.
+            let fillTime = afterAuction;
+            let remaining = MAKING_AMOUNT;
+            for (let i = 0; i < 3; i++) {
+                await time.setNextBlockTimestamp(fillTime);
+                const expected = takingAmountFor(order, params, fillTime, MAKING_AMOUNT / 10n, remaining);
+                const share = (MAKING_AMOUNT / 10n) * 10000n / remaining;
+                const interpolated = (share - 1000n) * BigInt(MATRIX[1]) + (2000n - share) * BigInt(MATRIX[0]);
+                const premium = i === 0 ? BigInt(MATRIX[0]) : interpolated / 1000n;
+                expect(expected).to.equal(ceilDiv((TAKING_AMOUNT / 10n) * (BASE_POINTS + premium), BASE_POINTS));
+                await expect(fill(lopv4, order, sig, MAKING_AMOUNT / 10n))
+                    .to.changeTokenBalances(weth, [taker, maker], [-expected, expected]);
+                remaining -= MAKING_AMOUNT / 10n;
+                fillTime++;
+            }
+        });
+
+        it('charges a late small fill by its share of the remainder, not its place on the original', async function () {
+            const { weth, lopv4, order, sig, params, afterAuction } = await deployMatrixOrder();
+
+            // With 80% already filled, a fill of 10% of the original order is half of what remains, so it
+            // prices at the 5/10 row — not at the nearly-free 9/10 row its cumulative end would land on.
+            await time.setNextBlockTimestamp(afterAuction);
+            await fill(lopv4, order, sig, MAKING_AMOUNT * 8n / 10n);
+
+            const fillTime = afterAuction + 1;
+            await time.setNextBlockTimestamp(fillTime);
+            const remaining = MAKING_AMOUNT * 2n / 10n;
+            const expected = takingAmountFor(order, params, fillTime, MAKING_AMOUNT / 10n, remaining);
+            expect(expected).to.equal(ceilDiv((TAKING_AMOUNT / 10n) * (BASE_POINTS + BigInt(MATRIX[4])), BASE_POINTS));
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT / 10n))
+                .to.changeTokenBalances(weth, [taker, maker], [-expected, expected]);
+        });
+
+        it('interpolates between matrix rows instead of stepping', async function () {
+            const { weth, lopv4, order, sig, params, afterAuction } = await deployMatrixOrder();
+
+            await time.setNextBlockTimestamp(afterAuction);
+            const makingAmount = MAKING_AMOUNT * 15n / 100n; // halfway between the 1/10 and 2/10 rows
+            const fillTx = fill(lopv4, order, sig, makingAmount);
+
+            const expected = takingAmountFor(order, params, afterAuction, makingAmount, MAKING_AMOUNT);
+            const midRowBump = BigInt(MATRIX[0] + MATRIX[1]) / 2n;
+            expect(expected).to.equal(ceilDiv(ceilDiv(TAKING_AMOUNT * 15n, 100n) * (BASE_POINTS + midRowBump), BASE_POINTS));
+            await expect(fillTx).to.changeTokenBalances(weth, [taker, maker], [-expected, expected]);
+        });
+
+        it('interpolates past the last row toward zero at completion', async function () {
+            const { lopv4, auction, order, params, afterAuction } = await deployMatrixOrder();
+
+            await time.setNextBlockTimestamp(afterAuction);
+            await hre.network.provider.send('evm_mine');
+
+            // The last explicit row sits at 9/10; a fill ending at 95% lands on the implied final segment,
+            // halfway between that row and the zero premium of completion.
+            const makingAmount = MAKING_AMOUNT * 95n / 100n;
+            const taking = await auction.getTakingAmount(
+                order, order.extension, await lopv4.hashOrder(order), taker.address, makingAmount, MAKING_AMOUNT, buildAnchoredAuctionDetails(params),
+            );
+            const halfLastRow = BigInt(MATRIX[8]) / 2n;
+            expect(taking).to.equal(ceilDiv(ceilDiv(TAKING_AMOUNT * 95n, 100n) * (BASE_POINTS + halfLastRow), BASE_POINTS));
+        });
+
+        it('offsets the gas bump from the matrix premium', async function () {
+            const contracts = await loadFixture(deployContractsAndInit);
+            const { dai, weth, lopv4, chainId, auction } = contracts;
+
+            const startTime = await time.latest() + 10;
+            const baseFee = 1000000000n; // 1 gwei, exactly the estimate below
+            const params = {
+                startTime,
+                duration: 100,
+                initialRateBump: Number(HALF_PERCENT),
+                fillPremiums: FILL_PREMIUMS,
+                gasBumpEstimate: Number(HALF_PERCENT * 4n), // 2%
+                gasPriceEstimate: 1000,
+            };
+            const order = await buildAuctionOrder({ dai, weth, auction, auctionDetails: buildAnchoredAuctionDetails(params) });
+            const sig = await signature(order, chainId, lopv4);
+
+            // After the auction the first decile carries the 4% row, and the 2% gas bump comes off it.
+            await hre.network.provider.send('hardhat_setNextBlockBaseFeePerGas', ['0x' + baseFee.toString(16)]);
+            await time.setNextBlockTimestamp(startTime + 200);
+            const fillTx = fill(lopv4, order, sig, MAKING_AMOUNT / 10n, { overrides: { gasPrice: baseFee * 2n } });
+
+            const expected = ceilDiv((TAKING_AMOUNT / 10n) * (BASE_POINTS + BigInt(MATRIX[0]) - HALF_PERCENT * 4n), BASE_POINTS);
+            await expect(fillTx).to.changeTokenBalances(weth, [taker, maker], [-expected, expected]);
+        });
+
+        it('never lets any split of the order undercut a single sweep', async function () {
+            const { lopv4, auction, order, params, afterAuction } = await deployMatrixOrder();
+            const singleRow = await deployMatrixOrder({ fillPremiums: { initial: Number(HALF_PERCENT), points: [] } });
+
+            await time.setNextBlockTimestamp(afterAuction + 1000);
+            await hre.network.provider.send('evm_mine');
+
+            // A seeded sweep over random partitions, priced through the contract's own view methods: for
+            // both curve shapes, no way of slicing the order may cost less in total than one full sweep.
+            let seed = 0xdead4351n;
+            const nextRand = (bound) => {
+                seed = (seed * 6364136223846793005n + 1442695040888963407n) & ((1n << 64n) - 1n);
+                return seed % bound;
+            };
+
+            for (const { o, p } of [{ o: order, p: params }, { o: singleRow.order, p: singleRow.params }]) {
+                const orderHash = await lopv4.hashOrder(o);
+                const extraData = buildAnchoredAuctionDetails(p);
+                const sweep = await auction.getTakingAmount(o, o.extension, orderHash, taker.address, MAKING_AMOUNT, MAKING_AMOUNT, extraData);
+
+                for (let trial = 0; trial < 8; trial++) {
+                    const chunks = [];
+                    let remaining = MAKING_AMOUNT;
+                    const parts = 2n + nextRand(4n);
+                    for (let i = 1n; i < parts; i++) {
+                        const chunk = 1n + nextRand(remaining - (parts - i));
+                        chunks.push(chunk);
+                        remaining -= chunk;
+                    }
+                    chunks.push(remaining);
+
+                    let total = 0n;
+                    let left = MAKING_AMOUNT;
+                    for (const chunk of chunks) {
+                        total += await auction.getTakingAmount(o, o.extension, orderHash, taker.address, chunk, left, extraData);
+                        left -= chunk;
+                    }
+                    expect(total, `partition ${chunks.join('+')}`).to.be.greaterThanOrEqual(sweep);
+                }
+            }
+        });
+
+        it('adds the matrix premium on top of the running time curve', async function () {
+            const { weth, lopv4, order, sig, params } = await deployMatrixOrder();
+
+            // Halfway through the auction the time curve still carries half the initial bump, and the
+            // 3/10-sized fill pays its matrix row on top of it.
+            const fillTime = params.startTime + 50;
+            await time.setNextBlockTimestamp(fillTime);
+            const makingAmount = MAKING_AMOUNT * 3n / 10n;
+            const fillTx = fill(lopv4, order, sig, makingAmount);
+
+            const expected = takingAmountFor(order, params, fillTime, makingAmount, MAKING_AMOUNT);
+            expect(expected).to.equal(ceilDiv(ceilDiv(TAKING_AMOUNT * 3n, 10n) * (BASE_POINTS + HALF_PERCENT / 2n + BigInt(MATRIX[2])), BASE_POINTS));
+            await expect(fillTx).to.changeTokenBalances(weth, [taker, maker], [-expected, expected]);
+        });
+
+        it('sweeps the remainder at the plain curve price', async function () {
+            const { weth, lopv4, order, sig, afterAuction } = await deployMatrixOrder();
+
+            await time.setNextBlockTimestamp(afterAuction);
+            await fill(lopv4, order, sig, MAKING_AMOUNT * 3n / 5n);
+
+            // Whatever its absolute size, taking everything that is left costs no premium at all.
+            await time.setNextBlockTimestamp(afterAuction + 10);
+            const remainder = MAKING_AMOUNT * 2n / 5n;
+            await expect(fill(lopv4, order, sig, remainder)).to.changeTokenBalances(
+                weth, [taker, maker], [-TAKING_AMOUNT * 2n / 5n, TAKING_AMOUNT * 2n / 5n],
+            );
+        });
+
+        it('prices a fill by taking amount no better than an exact solution would', async function () {
+            const { dai, lopv4, order, sig, params, afterAuction } = await deployMatrixOrder();
+
+            await time.setNextBlockTimestamp(afterAuction);
+            const takingAmount = TAKING_AMOUNT / 4n;
+            const fillTx = fill(lopv4, order, sig, takingAmount, { byMakingAmount: false });
+
+            const expected = makingAmountFor(order, params, afterAuction, takingAmount, MAKING_AMOUNT);
+            await expect(fillTx).to.changeTokenBalances(dai, [taker, maker], [expected, -expected]);
+
+            const exact = (() => {
+                let amount = expected;
+                for (let i = 0; i < 64; i++) {
+                    const rateBump = amount >= MAKING_AMOUNT ? 0n : fillPremiumAt(amount, MAKING_AMOUNT, FILL_PREMIUMS);
+                    amount = (order.makingAmount * takingAmount / order.takingAmount) * BASE_POINTS / (BASE_POINTS + rateBump);
+                }
+                return amount;
+            })();
+            expect(expected).to.be.lessThanOrEqual(exact);
+        });
+
+        it('works alongside anchoring', async function () {
+            const { weth, lopv4, registrator, order, sig, params } = await deployMatrixOrder({
+                startTime: 0,
+                anchored: true,
+            });
+
+            const announcedAt = await announce(registrator, order);
+            const resolved = { ...params, startTime: announcedAt };
+
+            const fillTime = announcedAt + 120; // past the anchored auction
+            await time.setNextBlockTimestamp(fillTime);
+            const makingAmount = MAKING_AMOUNT / 2n;
+            const expected = takingAmountFor(order, resolved, fillTime, makingAmount, MAKING_AMOUNT);
+            expect(expected).to.equal(ceilDiv((TAKING_AMOUNT / 2n) * (BASE_POINTS + BigInt(MATRIX[4])), BASE_POINTS));
+            await expect(fill(lopv4, order, sig, makingAmount)).to.changeTokenBalances(weth, [taker, maker], [-expected, expected]);
+        });
+
+        it('rejects a matrix whose premium rises along the ladder', async function () {
+            // A hump-shaped matrix: mid-sized fills pay the most. It is encodable, but a rising stretch
+            // makes two fills cheaper than their sum — a taker would be paid to split — so pricing off
+            // such a curve reverts instead.
+            const humpPremiums = {
+                initial: 100_000,
+                points: [
+                    { premium: 400_000, shareDelta: 3000 },
+                    { premium: 50_000, shareDelta: 4000 },
+                ],
+            };
+            const { lopv4, auction, order, sig, afterAuction } = await deployMatrixOrder({ fillPremiums: humpPremiums });
+
+            await time.setNextBlockTimestamp(afterAuction);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT * 3n / 10n))
+                .to.be.revertedWithCustomError(auction, 'NonMonotonicFillCurve');
+
+            // The taking-amount direction walks the same curve and refuses it the same way.
+            await expect(fill(lopv4, order, sig, TAKING_AMOUNT / 10n, { byMakingAmount: false }))
+                .to.be.revertedWithCustomError(auction, 'NonMonotonicFillCurve');
+        });
+
+        it('rejects a rising first row before any interior point is read', async function () {
+            // The initial premium is the curve's whole prefix for a vanishing fill, so a first row above
+            // it is caught on the very first comparison of the walk.
+            const risingPremiums = { initial: 50_000, points: [{ premium: 100_000, shareDelta: 5000 }] };
+            const { lopv4, auction, order, sig, afterAuction } = await deployMatrixOrder({ fillPremiums: risingPremiums });
+
+            await time.setNextBlockTimestamp(afterAuction);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT / 10n))
+                .to.be.revertedWithCustomError(auction, 'NonMonotonicFillCurve');
+        });
+
+        it('validates only the prefix a fill is actually priced on', async function () {
+            // Enforcement is lazy — one comparison per visited point — so a fill priced entirely on the
+            // legal early rows goes through even when a later stretch of the curve is broken, and the
+            // completing fill never reads the curve at all.
+            const brokenTail = {
+                initial: 300_000,
+                points: [
+                    { premium: 200_000, shareDelta: 3000 },
+                    { premium: 400_000, shareDelta: 4000 }, // illegal, but only for fills that reach it
+                ],
+            };
+            const { weth, lopv4, auction, order, sig, params, afterAuction } = await deployMatrixOrder({ fillPremiums: brokenTail });
+
+            await time.setNextBlockTimestamp(afterAuction);
+            const firstAmount = MAKING_AMOUNT * 2n / 10n;
+            const first = takingAmountFor(order, params, afterAuction, firstAmount, MAKING_AMOUNT);
+            await expect(fill(lopv4, order, sig, firstAmount)).to.changeTokenBalances(weth, [taker, maker], [-first, first]);
+
+            // Reaching past the legal prefix hits the rising row and reverts.
+            await time.setNextBlockTimestamp(afterAuction + 10);
+            await expect(fill(lopv4, order, sig, MAKING_AMOUNT * 3n / 10n))
+                .to.be.revertedWithCustomError(auction, 'NonMonotonicFillCurve');
+
+            // Completing the order short-circuits to the plain auction price without walking the curve.
+            await time.setNextBlockTimestamp(afterAuction + 20);
+            const rest = MAKING_AMOUNT - firstAmount;
+            const completing = takingAmountFor(order, params, afterAuction + 20, rest, rest);
+            await expect(fill(lopv4, order, sig, rest)).to.changeTokenBalances(weth, [taker, maker], [-completing, completing]);
         });
     });
 

--- a/test/helpers/anchoredAuction.js
+++ b/test/helpers/anchoredAuction.js
@@ -3,6 +3,7 @@ const { ethers } = require('hardhat');
 const BASE_POINTS = 10_000_000n; // 100%
 
 const ANCHORED_FLAG = 0x01n;
+const FILL_CURVE_FLAG = 0x02n;
 // Exclusivity-blob flag namespace: 0x01 is shared with ANCHORED_FLAG.
 const ANNOUNCEMENT_DEADLINE_FLAG = 0x02n;
 
@@ -37,6 +38,7 @@ function buildAnchoredAuctionDetails({
     duration = 0,
     initialRateBump = 0,
     anchored = false,
+    fillPremiums = undefined,
     points = [],
 } = {}) {
     let flags = 0n;
@@ -45,6 +47,15 @@ function buildAnchoredAuctionDetails({
 
     if (anchored) {
         flags |= ANCHORED_FLAG;
+    }
+    if (fillPremiums !== undefined) {
+        flags |= FILL_CURVE_FLAG;
+        types.push('uint24', 'uint8');
+        values.push(fillPremiums.initial, fillPremiums.points.length);
+        for (const { premium, shareDelta } of fillPremiums.points) {
+            types.push('uint24', 'uint16');
+            values.push(premium, shareDelta);
+        }
     }
 
     types.push('uint8');
@@ -116,6 +127,33 @@ function auctionBumpAt(timestamp, { startTime, duration, initialRateBump, points
     return (finish - now) * currentRateBump / (finish - currentPointTime);
 }
 
+const SHARE_BASE = 10_000n;
+
+/** Mirrors FusionAnchoredAuction._fillPremium: the fill's share of what remains, on a fresh ladder. */
+function fillPremiumAt(makingAmount, remainingMakingAmount, { initial, points = [] }) {
+    let currentPremium = BigInt(initial);
+    const share = makingAmount * SHARE_BASE / remainingMakingAmount;
+    if (share === 0n) return currentPremium;
+
+    let currentShare = 0n;
+    for (const { premium, shareDelta } of points) {
+        const nextPremium = BigInt(premium);
+        const nextShare = currentShare + BigInt(shareDelta);
+        if (share <= nextShare) {
+            return ((share - currentShare) * nextPremium + (nextShare - share) * currentPremium) / (nextShare - currentShare);
+        }
+        currentPremium = nextPremium;
+        currentShare = nextShare;
+    }
+    return (SHARE_BASE - share) * currentPremium / (SHARE_BASE - currentShare);
+}
+
+/** Mirrors FusionAnchoredAuction._rateBumpForFill. */
+function rateBumpForFill(rateBump, auction, makingAmount, remainingMakingAmount) {
+    if (!auction.fillPremiums || makingAmount >= remainingMakingAmount) return rateBump;
+    return rateBump + fillPremiumAt(makingAmount, remainingMakingAmount, auction.fillPremiums);
+}
+
 /** Mirrors the gas bump offset from the rate bump. */
 function applyGasBump(rateBump, gasBump) {
     return rateBump > gasBump ? rateBump - gasBump : 0n;
@@ -123,9 +161,23 @@ function applyGasBump(rateBump, gasBump) {
 
 /** Taking amount a fill by making amount is priced at. */
 function takingAmountFor(order, auction, timestamp, makingAmount, remainingMakingAmount, gasBump = 0n) {
-    const rateBump = applyGasBump(auctionBumpAt(timestamp, auction), gasBump);
+    const rateBump = applyGasBump(rateBumpForFill(auctionBumpAt(timestamp, auction), auction, makingAmount, remainingMakingAmount), gasBump);
     const unbumped = ceilDiv(order.takingAmount * makingAmount, order.makingAmount);
     return ceilDiv(unbumped * (BASE_POINTS + rateBump), BASE_POINTS);
+}
+
+/** Making amount a fill by taking amount is priced at, including the conservative fill-share estimate. */
+function makingAmountFor(order, auction, timestamp, takingAmount, remainingMakingAmount, gasBump = 0n) {
+    const bump = auctionBumpAt(timestamp, auction);
+    const unbumped = order.makingAmount * takingAmount / order.takingAmount;
+    let rateBump = bump;
+    if (auction.fillPremiums) {
+        // Premium curves are enforced non-increasing, so the initial premium is the worst one.
+        const worstRateBump = bump + BigInt(auction.fillPremiums.initial);
+        const estimate = unbumped * BASE_POINTS / (BASE_POINTS + applyGasBump(worstRateBump, gasBump));
+        rateBump = rateBumpForFill(bump, auction, estimate, remainingMakingAmount);
+    }
+    return unbumped * BASE_POINTS / (BASE_POINTS + applyGasBump(rateBump, gasBump));
 }
 
 module.exports = {
@@ -135,5 +187,7 @@ module.exports = {
     buildLegacyAuctionDetails,
     buildAnchoredAuctionDetails,
     buildAnchoredExclusivity,
+    fillPremiumAt,
     takingAmountFor,
+    makingAmountFor,
 };


### PR DESCRIPTION
Volume-ladder fill pricing behind auction flags bit 0x02: a fill pays a premium read from a piecewise curve over its share of the remaining making amount, interpolated between points with an implied final point of zero premium at the full remainder, so whoever completes the order pays no premium. The walk enforces monotonicity lazily and reverts a rising stretch as NonMonotonicFillCurve. The making-amount direction estimates the share at the worst rate bump and reprices from it, which can only overstate the bump.

## Change Summary
**What does this PR change?**
<!-- Describe the changes in 1-2 sentences -->

**Related Issue/Ticket:**
<!-- Link to JIRA ticket, GitHub issue, or change request -->

## Testing & Verification
**How was this tested?**
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing (describe steps)
- [ ] Verified on staging
<!-- Provide logs, screenshots, or steps to reproduce -->

## Risk Assessment
**Risk Level:**
- [ ] **Low** - Minor changes, no operational impact
- [ ] **Medium** - Moderate changes, limited impact, standard rollback available
- [ ] **High** - Significant changes, potential operational impact, complex rollback

**Risks & Impact**
<!-- Describe any possible risks, such as migrations, downtime, or breaking changes, etc. -->
